### PR TITLE
fix(desktop): vue-tsc зелёный в PaymentCard — каст payment.id к string

### DIFF
--- a/components/desktop/src/widgets/Cooperative/Payments/ListOfPayments/ui/PaymentCard.vue
+++ b/components/desktop/src/widgets/Cooperative/Payments/ListOfPayments/ui/PaymentCard.vue
@@ -32,11 +32,11 @@
           .row.justify-center.q-gutter-sm
             SetOrderPaidStatusButton(
               v-if='payment.id && ["PENDING", "FAILED", "EXPIRED"].includes(payment.status)',
-              :id='payment.id'
+              :id='String(payment.id)'
             )
             SetOrderRefundedStatusButton(
               v-if='payment.id && ["PENDING", "FAILED", "EXPIRED"].includes(payment.status)',
-              :id='payment.id'
+              :id='String(payment.id)'
             )
 
         q-card-section


### PR DESCRIPTION
## Summary

Cherry-pick из ветки `reports` (`425b3884d`). Сборка `dev` падает на `@coopenomics/desktop:build` двумя одинаковыми ошибками:

```
PaymentCard.vue(35,16): error TS2322: Type '{}' is not assignable to type 'string'.
PaymentCard.vue(39,16): error TS2322: Type '{}' is not assignable to type 'string'.
```

Zeus-скаляр `ID` разворачивается как непрозрачный `{}`, из-за чего `:id='payment.id'` не присваивается `string`-пропу кнопок. Явный `String(payment.id)` убирает обе ошибки `vue-tsc` без изменения runtime-поведения — `v-if` выше уже гарантирует truthy.

Фикс уже живёт в `reports`; тащим его в `dev` сейчас, чтобы разблокировать CI-сборку, не дожидаясь мёрджа большой ledger2-ветки. После мёржа `reports` этот же патч схлопнется по patch-id.

## Test plan

- [ ] `lerna run build` проходит без TS2322 в `@coopenomics/desktop`.
- [ ] Страница «Список платежей» открывается, кнопки с `:id='payment.id'` работают как раньше.

🤖 Generated with [Claude Code](https://claude.com/claude-code)