### PR TITLE
release: v2026.4.26-2 (production)

### DIFF
--- a/components/blago-cli/package.json
+++ b/components/blago-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/blago-cli",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "CLI синхронизации артефактов Благорост с бэкендом через @coopenomics/sdk",
   "type": "module",
   "private": true,

--- a/components/blago-cli/package.json
+++ b/components/blago-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/blago-cli",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "CLI синхронизации артефактов Благорост с бэкендом через @coopenomics/sdk",
   "type": "module",
   "private": true,

--- a/components/blago-cli/src/cmd/run-cli.ts
+++ b/components/blago-cli/src/cmd/run-cli.ts
@@ -41,6 +41,7 @@ import { runPush } from '../sync/push.js'
 import { runClearStaging, runRemove } from '../sync/remove.js'
 import { restoreAllFromServer, RESTORE_ALL_PATH_SENTINELS, runRestore } from '../sync/restore.js'
 import { runStatus } from '../sync/status.js'
+import { writeWorkspaceIndexMarkdown } from '../sync/workspace-index.js'
 import { error, formatThrownValue, info, success, warn } from '../ui/output.js'
 
 function startDir(): string {
@@ -372,6 +373,7 @@ export async function runCli(argv: string[]): Promise<void> {
         return
       }
       const restoredRel = await runRestore(ctx, pathOrId)
+      await writeWorkspaceIndexMarkdown(root)
       success(`Восстановлено с сервера: ${restoredRel}`)
     })
 
@@ -419,6 +421,7 @@ export async function runCli(argv: string[]): Promise<void> {
         return
       }
       await runClean(root)
+      await writeWorkspaceIndexMarkdown(root)
       success('Индекс и staging очищены, каталоги проектов удалены.')
     })
 

--- a/components/blago-cli/src/create/run-create-issue.ts
+++ b/components/blago-cli/src/create/run-create-issue.ts
@@ -24,6 +24,8 @@ import {
 } from '../sync/index-store.js'
 import { generateSlug, issueFileRelativePath, workspaceBasePath } from '../sync/layout.js'
 import { loadProjectMapsFromIndex } from '../sync/project-index-map.js'
+import { refreshParentProjectVersion } from '../sync/refresh-parent.js'
+import { writeWorkspaceIndexMarkdown } from '../sync/workspace-index.js'
 
 import { resolveProjectMarker } from './resolve-base.js'
 
@@ -220,7 +222,9 @@ export async function runCreateIssue(
     remote_updated_at: toRemoteIso(createdRow._updated_at),
     content_etag_local: etag,
   })
+  await refreshParentProjectVersion(ctx, index, createdRow.project_hash, projRow.parent_hash)
   await saveIndex(ctx.root, index)
   await appendPathsToStaging(ctx.root, [rel])
+  await writeWorkspaceIndexMarkdown(ctx.root)
   return { relativePath: rel }
 }

--- a/components/blago-cli/src/create/run-create-story.ts
+++ b/components/blago-cli/src/create/run-create-story.ts
@@ -21,6 +21,8 @@ import {
 import { generateSlug, storyFileRelativePath, workspaceBasePath } from '../sync/layout.js'
 import { loadProjectMapsFromIndex } from '../sync/project-index-map.js'
 import { issueLinkForStoryPath } from '../sync/push-create.js'
+import { refreshParentProjectVersion } from '../sync/refresh-parent.js'
+import { writeWorkspaceIndexMarkdown } from '../sync/workspace-index.js'
 
 import { resolveProjectMarker } from './resolve-base.js'
 import { storyContentFormatFromCliOption } from './story-format.js'
@@ -195,7 +197,11 @@ export async function runCreateStory(
     remote_updated_at: toRemoteIso(created._updated_at),
     content_etag_local: etag,
   })
+  if (created.project_hash) {
+    await refreshParentProjectVersion(ctx, index, String(created.project_hash), projRow.parent_hash)
+  }
   await saveIndex(ctx.root, index)
   await appendPathsToStaging(ctx.root, [rel])
+  await writeWorkspaceIndexMarkdown(ctx.root)
   return { relativePath: rel }
 }

--- a/components/blago-cli/src/create/run-create-story.ts
+++ b/components/blago-cli/src/create/run-create-story.ts
@@ -69,7 +69,7 @@ async function pickStoryFileRelativePath(
   const slug = generateSlug(title) || 'requirement'
   const id2 = storyRequirementIdPrefix2(storyRecordId, storyHash)
   const dir = issueArg?.titleSlug
-    ? `${basePath.replace(/\\/g, '/')}/requirements/${capitalIdPathPrefix(issueArg.id)}-${issueArg.titleSlug}`
+    ? `${basePath.replace(/\\/g, '/')}/issue-requirements/${capitalIdPathPrefix(issueArg.id)}-${issueArg.titleSlug}`
     : `${basePath.replace(/\\/g, '/')}/requirements`
   const alt = `${dir}/${id2}-${slug}-${storyHash.slice(0, 6)}.md`
   const absAlt = path.join(root, alt)

--- a/components/blago-cli/src/create/run-create-story.ts
+++ b/components/blago-cli/src/create/run-create-story.ts
@@ -69,7 +69,7 @@ async function pickStoryFileRelativePath(
   const slug = generateSlug(title) || 'requirement'
   const id2 = storyRequirementIdPrefix2(storyRecordId, storyHash)
   const dir = issueArg?.titleSlug
-    ? `${basePath.replace(/\\/g, '/')}/issues/${capitalIdPathPrefix(issueArg.id)}-${issueArg.titleSlug}-requirements`
+    ? `${basePath.replace(/\\/g, '/')}/requirements/${capitalIdPathPrefix(issueArg.id)}-${issueArg.titleSlug}`
     : `${basePath.replace(/\\/g, '/')}/requirements`
   const alt = `${dir}/${id2}-${slug}-${storyHash.slice(0, 6)}.md`
   const absAlt = path.join(root, alt)

--- a/components/blago-cli/src/sync/delete.ts
+++ b/components/blago-cli/src/sync/delete.ts
@@ -24,6 +24,8 @@ import {
   removePendingItem,
 } from './pending-create.js'
 import { loadProjectMapsFromIndex } from './project-index-map.js'
+import { refreshParentProjectVersion } from './refresh-parent.js'
+import { writeWorkspaceIndexMarkdown } from './workspace-index.js'
 
 export type BlagoDeleteKind = 'issue' | 'story'
 
@@ -104,10 +106,20 @@ export async function runDelete(
   }
 
   let entityHash = entry?.entity_hash ?? pending?.entity_hash ?? ''
-  if (!entityHash && fileContent !== null) {
+  let parentProjectHash: string | undefined
+  if (fileContent !== null) {
     try {
       const parsed = parseBlagoMarkdown(fileContent)
-      entityHash = String(parsed.data.hash ?? '').trim()
+      if (!entityHash) {
+        entityHash = String(parsed.data.hash ?? '').trim()
+      }
+      const ph = parsed.data.project_hash
+      if (ph !== undefined && ph !== null) {
+        const t = String(ph).trim()
+        if (t !== '') {
+          parentProjectHash = t
+        }
+      }
     }
     catch {
       // ignore
@@ -146,7 +158,27 @@ export async function runDelete(
     const nextEntries = index.entries.filter(
       e => !(e.entity_type === entry.entity_type && e.entity_hash === entry.entity_hash),
     )
-    await saveIndex(root, { entries: nextEntries })
+    const indexAfter: IndexFile = { entries: nextEntries }
+    if (remoteDeleted && parentProjectHash) {
+      const projEntryAfter = indexAfter.entries.find(
+        e => e.entity_type === 'project' && e.entity_hash === parentProjectHash,
+      )
+      let parentHashHint: string | null | undefined
+      if (projEntryAfter) {
+        try {
+          const pAbs = path.join(root, projEntryAfter.relative_path)
+          const pRaw = await fs.readFile(pAbs, 'utf8')
+          const pParsed = parseBlagoMarkdown(pRaw)
+          const v = pParsed.data.parent_hash
+          parentHashHint = v === undefined || v === null ? undefined : String(v)
+        }
+        catch {
+          parentHashHint = undefined
+        }
+      }
+      await refreshParentProjectVersion(ctx, indexAfter, parentProjectHash, parentHashHint)
+    }
+    await saveIndex(root, indexAfter)
   }
 
   if (isStaged) {
@@ -162,6 +194,8 @@ export async function runDelete(
       // ignore — возможная гонка или уже удалено
     }
   }
+
+  await writeWorkspaceIndexMarkdown(root)
 
   return { relativePath: rel, entityHash, remoteDeleted, pendingOnly }
 }

--- a/components/blago-cli/src/sync/ignore.ts
+++ b/components/blago-cli/src/sync/ignore.ts
@@ -3,8 +3,8 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 
-/** Всегда: служебные каталоги + маркер «текущий проект» (не документ Capital). */
-const DEFAULT_IGNORE = ['.blago/', '.git/', 'current_project.md']
+/** Всегда: служебные каталоги + маркер «текущий проект» + автогенерируемый INDEX.md (см. workspace-index). */
+const DEFAULT_IGNORE = ['.blago/', '.git/', 'current_project.md', 'INDEX.md']
 
 /** Каталоги BMAD: не документы Capital — не заходим при рекурсии add/remove и не индексируем по любому пути. */
 const SYNC_SKIP_DIR_SEGMENTS = new Set(['_bmad', '_bmad_output', '_bmad-output'])

--- a/components/blago-cli/src/sync/layout.ts
+++ b/components/blago-cli/src/sync/layout.ts
@@ -118,7 +118,7 @@ export function storyFileRelativePath(
   const id2 = storyRequirementIdPrefix2(storyRecordId, storyHash)
   if (issue?.titleSlug) {
     const ip = capitalIdPathPrefix(issue.id)
-    return `${basePath}/requirements/${ip}-${issue.titleSlug}/${id2}-${slug}.md`
+    return `${basePath}/issue-requirements/${ip}-${issue.titleSlug}/${id2}-${slug}.md`
   }
   return `${basePath}/requirements/${id2}-${slug}.md`
 }

--- a/components/blago-cli/src/sync/layout.ts
+++ b/components/blago-cli/src/sync/layout.ts
@@ -118,7 +118,7 @@ export function storyFileRelativePath(
   const id2 = storyRequirementIdPrefix2(storyRecordId, storyHash)
   if (issue?.titleSlug) {
     const ip = capitalIdPathPrefix(issue.id)
-    return `${basePath}/issues/${ip}-${issue.titleSlug}-requirements/${id2}-${slug}.md`
+    return `${basePath}/requirements/${ip}-${issue.titleSlug}/${id2}-${slug}.md`
   }
   return `${basePath}/requirements/${id2}-${slug}.md`
 }

--- a/components/blago-cli/src/sync/pull.ts
+++ b/components/blago-cli/src/sync/pull.ts
@@ -31,6 +31,7 @@ import {
 import { pullProjectCommunicationArtifacts } from './pull-communication.js'
 import { scaffoldBmadWorkspacesAfterPull } from './scaffold-bmad-workspace.js'
 import { syncEntityFile } from './sync-entity-file.js'
+import { writeWorkspaceIndexMarkdown } from './workspace-index.js'
 
 interface CapitalProjectRow {
   id?: number | null
@@ -344,6 +345,7 @@ export async function runPull(ctx: AuthenticatedContext, options: RunPullOptions
     currentCoopname: coopname,
   })
   await reportAndMaybePruneOrphans(ctx.root, orphans, options.prune === true)
+  await writeWorkspaceIndexMarkdown(ctx.root)
 }
 
 async function reportAndMaybePruneOrphans(

--- a/components/blago-cli/src/sync/push.ts
+++ b/components/blago-cli/src/sync/push.ts
@@ -28,6 +28,7 @@ import {
   pushCreateIssue,
   pushCreateStory,
 } from './push-create.js'
+import { writeWorkspaceIndexMarkdown } from './workspace-index.js'
 
 // Ответы GraphQL/Zeus часто дают _updated_at как unknown — сужаем безопасно.
 function toIso(v: unknown): string {
@@ -289,4 +290,5 @@ export async function runPush(ctx: AuthenticatedContext): Promise<void> {
 
   await saveIndex(ctx.root, index)
   await saveStaging(ctx.root, { paths: [...remaining] })
+  await writeWorkspaceIndexMarkdown(ctx.root)
 }

--- a/components/blago-cli/src/sync/refresh-parent.ts
+++ b/components/blago-cli/src/sync/refresh-parent.ts
@@ -1,0 +1,144 @@
+// После create/del дочерней issue/story сервер бьёт _updated_at родительского проекта.
+// Без обновления записи индекса родителя следующий push падает с конфликтом версий
+// (а pull может затереть локальные правки маркерами слияния). Этот хелпер освежает
+// remote_updated_at в индексе, не теряя несохранённые правки в файле проекта/компонента.
+
+import type { AuthenticatedContext } from '../session/index.js'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+import { Queries } from '@coopenomics/sdk'
+
+import { projectToFrontmatterAndBody, serializeBlagoMarkdown } from '../format/index.js'
+import { sha256Hex } from '../lib/hash.js'
+import { effectiveParentHash } from '../lib/parent-hash.js'
+import {
+  findByHash,
+  type IndexFile,
+  normalizeRelativePath,
+  upsertEntry,
+} from './index-store.js'
+
+interface CapitalProjectRow {
+  id?: number | null
+  project_hash: string
+  title?: string | null
+  description?: string | null
+  coopname: string
+  parent_hash?: string | null
+  parent_title?: string | null
+  status?: string | null
+  created_at?: Date | string | null
+  _updated_at?: Date | string | null
+}
+
+function toIso(v: Date | string | null | undefined): string {
+  if (v === undefined || v === null) {
+    return ''
+  }
+  if (v instanceof Date) {
+    return v.toISOString()
+  }
+  return new Date(v).toISOString()
+}
+
+/**
+ * Освежить запись индекса родительского проекта/компонента после мутации, которая на сервере
+ * бьёт его _updated_at (создание/удаление дочерней issue или story).
+ *
+ * - Если файл проекта/компонента «чистый» (etag совпадает с индексом) — переписываем файл
+ *   свежим контентом с сервера и обновляем remote_updated_at + content_etag_local.
+ * - Если файл «грязный» (есть локальные правки) — обновляем только remote_updated_at,
+ *   оставляя локальные правки нетронутыми. После такого освежения blago push сравнит
+ *   индекс с сервером и не найдёт конфликта.
+ *
+ * Тихие сбои: проекта нет в индексе / GraphQL недоступен / версия не сменилась → no-op.
+ *
+ * Безопасность от параллельной правки другим пользователем: если контент проекта на сервере
+ * отличается от того, что мы знали в индексе (по реконструированному etag без _updated_at),
+ * мы не выполняем «оптимистичный» bump — оставляем remote_updated_at прежним, чтобы
+ * пользователь увидел реальный конфликт при ближайшем push.
+ */
+export async function refreshParentProjectVersion(
+  ctx: AuthenticatedContext,
+  index: IndexFile,
+  projectHash: string,
+  parentHashHint: string | null | undefined,
+): Promise<void> {
+  const entry = findByHash(index, 'project', projectHash)
+  if (!entry) {
+    return
+  }
+  const parentHash = effectiveParentHash(parentHashHint ?? undefined)
+  let row: CapitalProjectRow | null = null
+  try {
+    const q = await ctx.client.Query(Queries.Capital.GetProject.query, {
+      variables: {
+        data: {
+          hash: projectHash,
+          parent_hash: parentHash,
+        },
+      },
+    })
+    row = (q[Queries.Capital.GetProject.name] as CapitalProjectRow | null) ?? null
+  }
+  catch {
+    return
+  }
+  if (!row) {
+    return
+  }
+  const newRemoteAt = toIso(row._updated_at)
+  if (!newRemoteAt || newRemoteAt === entry.remote_updated_at) {
+    return
+  }
+
+  const rel = normalizeRelativePath(entry.relative_path)
+  const abs = path.join(ctx.root, rel)
+  let onDisk: string | null = null
+  try {
+    onDisk = await fs.readFile(abs, 'utf8')
+  }
+  catch {
+    onDisk = null
+  }
+
+  // Реконструируем «как выглядел бы файл» с сервера, но с _updated_at == прежнее значение из индекса:
+  // если получится то же содержимое, что в индексе по etag — содержимое (title/description) не менялось,
+  // bump _updated_at действительно «наш» (вызван дочерней мутацией) и его безопасно записать в индекс.
+  const previewRow: CapitalProjectRow = { ...row, _updated_at: entry.remote_updated_at }
+  const { data: prevData, body: prevBody } = projectToFrontmatterAndBody(previewRow)
+  const previewEtag = sha256Hex(serializeBlagoMarkdown(prevData, prevBody))
+  const contentUnchangedOnServer = previewEtag === entry.content_etag_local
+
+  if (!contentUnchangedOnServer) {
+    // Сервер опередил нас (правка извне или через другую копию) — не трогаем индекс,
+    // пусть push выявит реальный конфликт и пользователь сделает осознанный pull.
+    return
+  }
+
+  const isDirty = onDisk !== null && sha256Hex(onDisk) !== entry.content_etag_local
+  if (!isDirty) {
+    const { data, body } = projectToFrontmatterAndBody(row)
+    const content = serializeBlagoMarkdown(data, body)
+    await fs.mkdir(path.dirname(abs), { recursive: true })
+    await fs.writeFile(abs, content, 'utf8')
+    const etag = sha256Hex(await fs.readFile(abs, 'utf8'))
+    upsertEntry(index, {
+      entity_type: 'project',
+      entity_hash: projectHash,
+      relative_path: rel,
+      remote_updated_at: newRemoteAt,
+      content_etag_local: etag,
+    })
+    return
+  }
+
+  upsertEntry(index, {
+    entity_type: 'project',
+    entity_hash: projectHash,
+    relative_path: rel,
+    remote_updated_at: newRemoteAt,
+    content_etag_local: entry.content_etag_local,
+  })
+}

--- a/components/blago-cli/src/sync/restore.ts
+++ b/components/blago-cli/src/sync/restore.ts
@@ -44,6 +44,7 @@ import {
 } from './layout.js'
 import { loadProjectMapsFromIndex } from './project-index-map.js'
 import { resolveProjectMarkerFromRelativePath } from './resolve-project-hash-from-path.js'
+import { writeWorkspaceIndexMarkdown } from './workspace-index.js'
 
 interface CapitalProjectRow {
   id?: number | null
@@ -512,5 +513,6 @@ export async function restoreAllFromServer(ctx: AuthenticatedContext): Promise<R
       failures.push({ relativePath: rel, message: formatThrownValue(caught) })
     }
   }
+  await writeWorkspaceIndexMarkdown(ctx.root)
   return { restored, failures }
 }

--- a/components/blago-cli/src/sync/sync-entity-file.ts
+++ b/components/blago-cli/src/sync/sync-entity-file.ts
@@ -23,6 +23,28 @@ async function fileExists(abs: string): Promise<boolean> {
   }
 }
 
+/** После переноса файла прибрать пустые родительские каталоги (но не выше rootAbs). */
+async function pruneEmptyParents(absFile: string, rootAbs: string): Promise<void> {
+  const stopAt = path.resolve(rootAbs)
+  let dir = path.resolve(path.dirname(absFile))
+  for (let i = 0; i < 16; i++) {
+    if (dir === stopAt || !dir.startsWith(`${stopAt}${path.sep}`)) {
+      return
+    }
+    try {
+      const entries = await fs.readdir(dir)
+      if (entries.length > 0) {
+        return
+      }
+      await fs.rmdir(dir)
+    }
+    catch {
+      return
+    }
+    dir = path.dirname(dir)
+  }
+}
+
 async function readFileIfExists(abs: string): Promise<string | null> {
   try {
     return await fs.readFile(abs, 'utf8')
@@ -78,6 +100,7 @@ export async function syncEntityFile(params: {
       await ensureDirForFile(absNew)
       if (await fileExists(absOld)) {
         await fs.rename(absOld, absNew)
+        await pruneEmptyParents(absOld, root)
       }
       else {
         await fs.writeFile(absNew, content, 'utf8')
@@ -99,6 +122,7 @@ export async function syncEntityFile(params: {
     await fs.writeFile(absNew, content, 'utf8')
     if ((await fileExists(absOld)) && path.resolve(absOld) !== path.resolve(absNew)) {
       await fs.unlink(absOld)
+      await pruneEmptyParents(absOld, root)
     }
     const etagAfterRename = sha256Hex(await fs.readFile(absNew, 'utf8'))
     upsertEntry(index, {

--- a/components/blago-cli/src/sync/workspace-index.ts
+++ b/components/blago-cli/src/sync/workspace-index.ts
@@ -66,9 +66,10 @@ export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
   const index = await loadIndex(root)
   const projects: ProjectRow[] = []
   const stories: StoryRow[] = []
+  const issueIdByHash = new Map<string, string>()
 
   for (const e of index.entries) {
-    if (e.entity_type !== 'project' && e.entity_type !== 'story') {
+    if (e.entity_type !== 'project' && e.entity_type !== 'story' && e.entity_type !== 'issue') {
       continue
     }
     const rel = normalizeRelativePath(e.relative_path)
@@ -96,6 +97,13 @@ export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
           : String(parsed.data.parent_hash),
       )
       projects.push({ id, hash: e.entity_hash, title, rel, parentHash: parent })
+    }
+    else if (e.entity_type === 'issue') {
+      // Задачи в INDEX.md не выводятся (слишком много шума), но id нужен
+      // для подписи под требованиями, привязанными к задаче (issue_hash).
+      if (id !== undefined) {
+        issueIdByHash.set(e.entity_hash, id)
+      }
     }
     else {
       const projectHash = parsed.data.project_hash === undefined || parsed.data.project_hash === null
@@ -158,8 +166,12 @@ export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
   else {
     for (const s of stories) {
       const ownerLabel = s.projectHash ? projectIdByHash.get(s.projectHash) ?? '?' : '?'
+      const issueLabel = s.issueHash ? issueIdByHash.get(s.issueHash) : undefined
+      const owner = issueLabel
+        ? `задача ${issueLabel} в ${ownerLabel}`
+        : `проект/компонент ${ownerLabel}`
       out.push(
-        `- **${shortDisplayId(s.id)}** — ${s.title || '(без названия)'} (проект/компонент ${ownerLabel}) → \`${s.rel}\``,
+        `- **${shortDisplayId(s.id)}** — ${s.title || '(без названия)'} (${owner}) → \`${s.rel}\``,
       )
     }
   }

--- a/components/blago-cli/src/sync/workspace-index.ts
+++ b/components/blago-cli/src/sync/workspace-index.ts
@@ -1,0 +1,195 @@
+// INDEX.md в корне рабочей копии: для быстрого поиска проекта/компонента/требования/задачи
+// по id или фрагменту названия (LLM-агентам не нужно ходить по дереву ls'ом).
+// Обновляется автоматически на pull/push/create/del/restore/clean.
+
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+import { parseBlagoMarkdown } from '../format/index.js'
+import { effectiveParentHash } from '../lib/parent-hash.js'
+import { loadIndex, normalizeRelativePath } from './index-store.js'
+
+interface ProjectRow {
+  readonly id?: string
+  readonly hash: string
+  readonly title: string
+  readonly rel: string
+  readonly parentHash?: string
+}
+
+interface IssueRow {
+  readonly id?: string
+  readonly hash: string
+  readonly title: string
+  readonly rel: string
+  readonly projectHash: string
+}
+
+interface StoryRow {
+  readonly id?: string
+  readonly hash: string
+  readonly title: string
+  readonly rel: string
+  readonly projectHash?: string
+  readonly issueHash?: string
+}
+
+const INDEX_MARKDOWN_FILENAME = 'INDEX.md'
+
+function pickIdString(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined
+  }
+  const s = String(raw).trim()
+  return s === '' ? undefined : s
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Идентификаторы требований приходят как UUID — для индекса оставляем первые 8 символов
+ *  (uniqueness в рамках копии практически 100%, поиск по полному id всё равно работает через frontmatter). */
+function shortDisplayId(id: string | undefined): string {
+  if (id === undefined) {
+    return '?'
+  }
+  if (UUID_RE.test(id)) {
+    return id.slice(0, 8)
+  }
+  return id
+}
+
+function sortByIdNumeric<T extends { id?: string, title: string }>(a: T, b: T): number {
+  const ai = a.id ?? ''
+  const bi = b.id ?? ''
+  const cmp = ai.localeCompare(bi, 'en', { numeric: true, sensitivity: 'base' })
+  if (cmp !== 0) {
+    return cmp
+  }
+  return a.title.localeCompare(b.title, 'ru')
+}
+
+export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
+  const index = await loadIndex(root)
+  const projects: ProjectRow[] = []
+  const issues: IssueRow[] = []
+  const stories: StoryRow[] = []
+
+  for (const e of index.entries) {
+    if (e.entity_type !== 'project' && e.entity_type !== 'issue' && e.entity_type !== 'story') {
+      continue
+    }
+    const rel = normalizeRelativePath(e.relative_path)
+    const abs = path.join(root, rel)
+    let raw: string
+    try {
+      raw = await fs.readFile(abs, 'utf8')
+    }
+    catch {
+      continue
+    }
+    let parsed
+    try {
+      parsed = parseBlagoMarkdown(raw)
+    }
+    catch {
+      continue
+    }
+    const id = pickIdString(parsed.data.id)
+    const title = String(parsed.data.title ?? '').trim()
+    if (e.entity_type === 'project') {
+      const parent = effectiveParentHash(
+        parsed.data.parent_hash === undefined || parsed.data.parent_hash === null
+          ? undefined
+          : String(parsed.data.parent_hash),
+      )
+      projects.push({ id, hash: e.entity_hash, title, rel, parentHash: parent })
+    }
+    else if (e.entity_type === 'issue') {
+      const projectHash = String(parsed.data.project_hash ?? '').trim()
+      issues.push({ id, hash: e.entity_hash, title, rel, projectHash })
+    }
+    else {
+      const projectHash = parsed.data.project_hash === undefined || parsed.data.project_hash === null
+        ? undefined
+        : String(parsed.data.project_hash).trim() || undefined
+      const issueHash = parsed.data.issue_hash === undefined || parsed.data.issue_hash === null
+        ? undefined
+        : String(parsed.data.issue_hash).trim() || undefined
+      stories.push({ id, hash: e.entity_hash, title, rel, projectHash, issueHash })
+    }
+  }
+
+  projects.sort(sortByIdNumeric)
+  issues.sort(sortByIdNumeric)
+  stories.sort(sortByIdNumeric)
+
+  const projectIdByHash = new Map<string, string>()
+  for (const p of projects) {
+    projectIdByHash.set(p.hash, p.id ?? p.hash.slice(0, 8))
+  }
+
+  const rootProjects = projects.filter(p => !p.parentHash)
+  const components = projects.filter(p => p.parentHash)
+
+  const out: string[] = []
+  out.push('# Blago Workspace Index')
+  out.push('')
+  out.push(
+    '> Сгенерировано автоматически (`blago pull` / `push` / `create` / `del` / `restore`). '
+    + 'Не править вручную — будет перезаписано.',
+  )
+  out.push('')
+
+  out.push('## Проекты')
+  if (rootProjects.length === 0) {
+    out.push('_(пусто)_')
+  }
+  else {
+    for (const p of rootProjects) {
+      out.push(`- **${shortDisplayId(p.id)}** — ${p.title || '(без названия)'} → \`${p.rel}\``)
+    }
+  }
+  out.push('')
+
+  out.push('## Компоненты')
+  if (components.length === 0) {
+    out.push('_(пусто)_')
+  }
+  else {
+    for (const c of components) {
+      const parentLabel = c.parentHash ? projectIdByHash.get(c.parentHash) ?? '?' : '?'
+      out.push(`- **${shortDisplayId(c.id)}** — ${c.title || '(без названия)'} (проект ${parentLabel}) → \`${c.rel}\``)
+    }
+  }
+  out.push('')
+
+  out.push('## Требования')
+  if (stories.length === 0) {
+    out.push('_(пусто)_')
+  }
+  else {
+    for (const s of stories) {
+      const ownerLabel = s.projectHash ? projectIdByHash.get(s.projectHash) ?? '?' : '?'
+      out.push(
+        `- **${shortDisplayId(s.id)}** — ${s.title || '(без названия)'} (проект/компонент ${ownerLabel}) → \`${s.rel}\``,
+      )
+    }
+  }
+  out.push('')
+
+  out.push('## Задачи')
+  if (issues.length === 0) {
+    out.push('_(пусто)_')
+  }
+  else {
+    for (const i of issues) {
+      const ownerLabel = i.projectHash ? projectIdByHash.get(i.projectHash) ?? '?' : '?'
+      out.push(
+        `- **${shortDisplayId(i.id)}** — ${i.title || '(без названия)'} (проект/компонент ${ownerLabel}) → \`${i.rel}\``,
+      )
+    }
+  }
+  out.push('')
+
+  await fs.writeFile(path.join(root, INDEX_MARKDOWN_FILENAME), `${out.join('\n')}`, 'utf8')
+}

--- a/components/blago-cli/src/sync/workspace-index.ts
+++ b/components/blago-cli/src/sync/workspace-index.ts
@@ -1,5 +1,7 @@
-// INDEX.md в корне рабочей копии: для быстрого поиска проекта/компонента/требования/задачи
+// INDEX.md в корне рабочей копии: для быстрого поиска проекта/компонента/требования
 // по id или фрагменту названия (LLM-агентам не нужно ходить по дереву ls'ом).
+// Задачи (issues) сюда намеренно не попадают: их слишком много, ищут их с привязкой
+// к проекту/компоненту, а сам проект/компонент находится по этому индексу.
 // Обновляется автоматически на pull/push/create/del/restore/clean.
 
 import * as fs from 'node:fs/promises'
@@ -15,14 +17,6 @@ interface ProjectRow {
   readonly title: string
   readonly rel: string
   readonly parentHash?: string
-}
-
-interface IssueRow {
-  readonly id?: string
-  readonly hash: string
-  readonly title: string
-  readonly rel: string
-  readonly projectHash: string
 }
 
 interface StoryRow {
@@ -71,11 +65,10 @@ function sortByIdNumeric<T extends { id?: string, title: string }>(a: T, b: T): 
 export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
   const index = await loadIndex(root)
   const projects: ProjectRow[] = []
-  const issues: IssueRow[] = []
   const stories: StoryRow[] = []
 
   for (const e of index.entries) {
-    if (e.entity_type !== 'project' && e.entity_type !== 'issue' && e.entity_type !== 'story') {
+    if (e.entity_type !== 'project' && e.entity_type !== 'story') {
       continue
     }
     const rel = normalizeRelativePath(e.relative_path)
@@ -104,10 +97,6 @@ export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
       )
       projects.push({ id, hash: e.entity_hash, title, rel, parentHash: parent })
     }
-    else if (e.entity_type === 'issue') {
-      const projectHash = String(parsed.data.project_hash ?? '').trim()
-      issues.push({ id, hash: e.entity_hash, title, rel, projectHash })
-    }
     else {
       const projectHash = parsed.data.project_hash === undefined || parsed.data.project_hash === null
         ? undefined
@@ -120,7 +109,6 @@ export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
   }
 
   projects.sort(sortByIdNumeric)
-  issues.sort(sortByIdNumeric)
   stories.sort(sortByIdNumeric)
 
   const projectIdByHash = new Map<string, string>()
@@ -172,20 +160,6 @@ export async function writeWorkspaceIndexMarkdown(root: string): Promise<void> {
       const ownerLabel = s.projectHash ? projectIdByHash.get(s.projectHash) ?? '?' : '?'
       out.push(
         `- **${shortDisplayId(s.id)}** — ${s.title || '(без названия)'} (проект/компонент ${ownerLabel}) → \`${s.rel}\``,
-      )
-    }
-  }
-  out.push('')
-
-  out.push('## Задачи')
-  if (issues.length === 0) {
-    out.push('_(пусто)_')
-  }
-  else {
-    for (const i of issues) {
-      const ownerLabel = i.projectHash ? projectIdByHash.get(i.projectHash) ?? '?' : '?'
-      out.push(
-        `- **${shortDisplayId(i.id)}** — ${i.title || '(без названия)'} (проект/компонент ${ownerLabel}) → \`${i.rel}\``,
       )
     }
   }

--- a/components/boot/package.json
+++ b/components/boot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/boot",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "CLI-утилита инициализации блокчейна и кооператива",

--- a/components/boot/package.json
+++ b/components/boot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/boot",
   "type": "module",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "CLI-утилита инициализации блокчейна и кооператива",

--- a/components/cleos/package.json
+++ b/components/cleos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/cleos",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "private": true,
   "description": "Обёртка над кошельком cleos для EOSIO блокчейна",
   "scripts": {

--- a/components/cleos/package.json
+++ b/components/cleos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/cleos",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "private": true,
   "description": "Обёртка над кошельком cleos для EOSIO блокчейна",
   "scripts": {

--- a/components/contracts/package.json
+++ b/components/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/contracts",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/components/contracts/package.json
+++ b/components/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/contracts",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/components/contracts/standards-site/src/components/FocusBar.vue
+++ b/components/contracts/standards-site/src/components/FocusBar.vue
@@ -158,8 +158,6 @@ const focusMode = computed<
   return 'none';
 });
 
-const relatedCount = computed(() => (props.standard.related ?? []).length);
-
 // ── Данные для «завершения отказом» ─────────────────────────────────────
 interface RejectedInfo {
   transition: Transition;

--- a/components/controller/package-lock.json
+++ b/components/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-nodejs-express-app",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-nodejs-express-app",
-      "version": "2026.4.24-2",
+      "version": "2026.4.26-alpha-1",
       "license": "MIT",
       "dependencies": {
         "@a2seven/yoo-checkout": "^1.1.4",

--- a/components/controller/package-lock.json
+++ b/components/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-nodejs-express-app",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-nodejs-express-app",
-      "version": "2026.4.26-alpha-1",
+      "version": "2026.4.26-2",
       "license": "MIT",
       "dependencies": {
         "@a2seven/yoo-checkout": "^1.1.4",

--- a/components/controller/package.json
+++ b/components/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/controller",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "Бэкенд GraphQL API кооператива на NestJS",
   "private": true,
   "bin": "bin/createNodejsApp.js",

--- a/components/controller/package.json
+++ b/components/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/controller",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "Бэкенд GraphQL API кооператива на NestJS",
   "private": true,
   "bin": "bin/createNodejsApp.js",

--- a/components/controller/src/extensions/capital/application/dto/generation/story-filter.input.ts
+++ b/components/controller/src/extensions/capital/application/dto/generation/story-filter.input.ts
@@ -53,8 +53,8 @@ export class StoryFilterInputDTO {
 
   @Field(() => Boolean, {
     nullable: true,
-    description: 'Показывать требования задач при фильтрации по project_hash',
-    defaultValue: true,
+    description: 'Показывать требования задач при фильтрации по project_hash (по умолчанию false: задачные требования живут на странице задачи и не аккумулируются на проект/компонент)',
+    defaultValue: false,
   })
   show_issues_requirements?: boolean;
 }

--- a/components/controller/src/extensions/capital/application/services/generation.service.ts
+++ b/components/controller/src/extensions/capital/application/services/generation.service.ts
@@ -401,11 +401,13 @@ export class GenerationService {
       return [];
     }
 
-    let anchorProjectHash = story.project_hash?.trim() ?? '';
-    if (!anchorProjectHash && story.issue_hash) {
-      const issue = await this.issueRepository.findByIssueHash(story.issue_hash);
-      anchorProjectHash = issue?.project_hash?.trim() ?? '';
+    // Требования к задаче (issue_hash задан) видны только на странице задачи и не публикуются
+    // в проектные/компонентные matrix-комнаты, чтобы не зашумлять основной канал проекта.
+    if (story.issue_hash && story.issue_hash.trim() !== '') {
+      return [];
     }
+
+    const anchorProjectHash = story.project_hash?.trim() ?? '';
     if (!anchorProjectHash) {
       return [];
     }
@@ -665,8 +667,10 @@ export class GenerationService {
       // Определяем, нужно ли включать требования дочерних компонентов
       const showComponentsRequirements = filter.show_components_requirements !== false; // По умолчанию true
 
-      // Определяем, нужно ли включать требования задач
-      const showIssuesRequirements = filter.show_issues_requirements !== false; // По умолчанию true
+      // Задачные требования (story с issue_hash) живут только на странице задачи и не
+      // аккумулируются на проект/компонент: дефолт false, явный true оставлен на случай
+      // обратной потребности.
+      const showIssuesRequirements = filter.show_issues_requirements === true;
 
       // Собираем все project_hash для фильтрации
       let projectHashesToFilter: string[] = [filter.project_hash];

--- a/components/cooptypes/package.json
+++ b/components/cooptypes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cooptypes",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "Shared TypeScript типы и интерфейсы экосистемы кооперативов",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/cooptypes/package.json
+++ b/components/cooptypes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cooptypes",
   "type": "module",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "Shared TypeScript типы и интерфейсы экосистемы кооперативов",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/desktop/extensions/capital/features/Story/CreateStory/ui/Dialog/CreateRequirementWithEditorDialog.vue
+++ b/components/desktop/extensions/capital/features/Story/CreateStory/ui/Dialog/CreateRequirementWithEditorDialog.vue
@@ -106,6 +106,9 @@ import type { IStory } from 'app/extensions/capital/entities/Story/model';
 const props = defineProps<{
   filter?: {
     project_hash?: string;
+    /** Хеш задачи — артефакт привязывается к задаче и не аккумулируется на проекте/компоненте */
+    issue_hash?: string;
+    /** @deprecated legacy: используйте issue_hash */
     issue_id?: string;
   };
 }>();

--- a/components/desktop/extensions/capital/features/Story/CreateStory/ui/Fab/CreateRequirementFabAction.vue
+++ b/components/desktop/extensions/capital/features/Story/CreateStory/ui/Fab/CreateRequirementFabAction.vue
@@ -26,6 +26,9 @@ import type { IProjectPermissions } from 'app/extensions/capital/entities/Projec
 const props = withDefaults(defineProps<{
   filter?: {
     project_hash?: string;
+    /** Хеш задачи — артефакт привязывается к задаче и не аккумулируется на проекте/компоненте */
+    issue_hash?: string;
+    /** @deprecated legacy: используйте issue_hash */
     issue_id?: string;
   };
   permissions?: IIssuePermissions | IProjectPermissions | null;

--- a/components/desktop/extensions/capital/pages/IssuePage/ui/IssuePage.vue
+++ b/components/desktop/extensions/capital/pages/IssuePage/ui/IssuePage.vue
@@ -58,6 +58,31 @@ div.column.flex-1.min-h-0.min-w-0.no-wrap
 
         q-expansion-item.q-px-md.q-mt-md(
           v-if='issue'
+          icon='assignment'
+          label='Требования к задаче'
+          :caption='requirementsCaption'
+          header-class='text-grey-7'
+          dense-toggle
+          default-opened
+        )
+          RequirementsListWidget(
+            :filter='requirementsFilter'
+            :max-items='50'
+            :permissions='issue.permissions'
+          )
+          .row.justify-end.q-mt-sm(v-if='canCreateRequirement')
+            q-btn(
+              flat
+              dense
+              no-caps
+              color='primary'
+              icon='add'
+              label='Добавить требование'
+              @click='openCreateRequirementDialog'
+            )
+
+        q-expansion-item.q-px-md.q-mt-md(
+          v-if='issue'
           icon='schedule'
           label='История рабочего времени'
           :caption='worklogCaption'
@@ -135,6 +160,31 @@ div.column.flex-1.min-h-0.min-w-0.no-wrap
 
             q-expansion-item.q-px-md.q-mt-md(
               v-if='issue'
+              icon='assignment'
+              label='Требования к задаче'
+              :caption='requirementsCaption'
+              header-class='text-grey-7'
+              dense-toggle
+              default-opened
+            )
+              RequirementsListWidget(
+                :filter='requirementsFilter'
+                :max-items='50'
+                :permissions='issue.permissions'
+              )
+              .row.justify-end.q-mt-sm(v-if='canCreateRequirement')
+                q-btn(
+                  flat
+                  dense
+                  no-caps
+                  color='primary'
+                  icon='add'
+                  label='Добавить требование'
+                  @click='openCreateRequirementDialog'
+                )
+
+            q-expansion-item.q-px-md.q-mt-md(
+              v-if='issue'
               icon='schedule'
               label='История рабочего времени'
               :caption='worklogCaption'
@@ -144,6 +194,12 @@ div.column.flex-1.min-h-0.min-w-0.no-wrap
               TimeEntriesWidget(
                 :issue-hash='issue.issue_hash'
               )
+
+  CreateRequirementWithEditorDialog(
+    ref='createRequirementDialog'
+    :filter='createRequirementFilter'
+    @success='handleRequirementCreated'
+  )
 </template>
 
 <script lang="ts" setup>
@@ -163,6 +219,9 @@ import { useUpdateIssue } from 'app/extensions/capital/features/Issue/UpdateIssu
 import { IssueSidebarWidget, IssueLinkedGitCommitsWidget, TimeEntriesWidget } from 'app/extensions/capital/widgets';
 import { IssueTitleEditor } from 'app/extensions/capital/widgets/IssueTitleEditor';
 import { ProjectPathWidget } from 'app/extensions/capital/widgets/ProjectPathWidget';
+import { RequirementsListWidget } from 'app/extensions/capital/widgets/RequirementsListWidget';
+import { CreateRequirementWithEditorDialog } from 'app/extensions/capital/features/Story/CreateStory';
+import { useStoryStore, type IGetStoriesInput } from 'app/extensions/capital/entities/Story/model';
 
 const route = useRoute();
 const router = useRouter();
@@ -214,6 +273,41 @@ const projectHash = computed(() => route.params.project_hash as string);
 const parentHash = computed(() => projectHash.value);
 
 const linkedGitCommits = computed(() => issue.value?.linked_git_commits ?? []);
+
+// Фильтр для виджета требований — story только этой задачи
+const requirementsFilter = computed<Partial<IGetStoriesInput['filter']>>(() => ({
+  issue_hash: issue.value?.issue_hash ?? '',
+}));
+
+// Фильтр для диалога создания — issue_hash + project_hash родителя
+const createRequirementFilter = computed(() => ({
+  project_hash: projectHash.value,
+  issue_hash: issue.value?.issue_hash ?? '',
+}));
+
+// Право на создание требования к задаче
+const canCreateRequirement = computed((): boolean => {
+  return Boolean(issue.value?.permissions?.can_create_requirement);
+});
+
+// Подпись рядом с заголовком «Требования к задаче»
+const storyStore = useStoryStore();
+const requirementsCaption = computed(() => {
+  const stored = storyStore.stories;
+  const cur = issue.value?.issue_hash;
+  if (!cur || !stored) return '';
+  const count = stored.items.filter((s) => s.issue_hash === cur).length;
+  if (count === 0) return 'пока пусто';
+  return `${count} шт.`;
+});
+
+const createRequirementDialog = ref<InstanceType<typeof CreateRequirementWithEditorDialog> | null>(null);
+const openCreateRequirementDialog = () => {
+  createRequirementDialog.value?.openDialog();
+};
+const handleRequirementCreated = () => {
+  // RequirementsListWidget сам подцепит новый story через store
+};
 
 // Подпись рядом с заголовком «История рабочего времени» — отражает факт/план одной строкой.
 const worklogCaption = computed(() => {

--- a/components/desktop/extensions/capital/widgets/RequirementsListWidget/ui/RequirementsListWidget.vue
+++ b/components/desktop/extensions/capital/widgets/RequirementsListWidget/ui/RequirementsListWidget.vue
@@ -89,13 +89,14 @@ import { api as IssueApi } from 'app/extensions/capital/entities/Issue/api';
 import { DeleteStoryButton } from 'app/extensions/capital/features/Story/DeleteStory';
 import { EditRequirementDialog } from 'app/extensions/capital/features/Story/EditRequirement';
 import type { IProjectPermissions } from 'app/extensions/capital/entities/Project/model';
+import type { IIssuePermissions } from 'app/extensions/capital/entities/Issue/model';
 import { EntityIdBadge } from 'src/shared/ui/EntityIdBadge';
 
 const props = withDefaults(
   defineProps<{
     filter?: Partial<IGetStoriesInput['filter']>;
     maxItems?: number;
-    permissions?: IProjectPermissions | null;
+    permissions?: IProjectPermissions | IIssuePermissions | null;
     /** Имя маршрута карточки артефакта (project-requirement-detail / component-requirement-detail) */
     detailRouteName?: string;
     /** На странице артефактов корневого проекта — подпись и ссылка на компонент для чужих project_hash */

--- a/components/desktop/package.json
+++ b/components/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/desktop",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "Рабочий стол кооператива — Vue 3 + Quasar Framework",
   "productName": "Desktop App",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",

--- a/components/desktop/package.json
+++ b/components/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/desktop",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "Рабочий стол кооператива — Vue 3 + Quasar Framework",
   "productName": "Desktop App",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",

--- a/components/docs/package.json
+++ b/components/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/docs",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "description": "Документация для монорепозитория",

--- a/components/docs/package.json
+++ b/components/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/docs",
   "type": "module",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "description": "Документация для монорепозитория",

--- a/components/factory/package.json
+++ b/components/factory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/factory",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "Фабрика юридических документов кооператива",
   "author": "Alex Ant <chairman.voskhod@gmail.com>",
   "license": "MIT",

--- a/components/factory/package.json
+++ b/components/factory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/factory",
   "type": "module",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "Фабрика юридических документов кооператива",
   "author": "Alex Ant <chairman.voskhod@gmail.com>",
   "license": "MIT",

--- a/components/inter/package.json
+++ b/components/inter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/inter",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "Контракты и DI-токены для связи расширений контроллера без прямых зависимостей",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/inter/package.json
+++ b/components/inter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/inter",
   "type": "module",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "Контракты и DI-токены для связи расширений контроллера без прямых зависимостей",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/migrator/package.json
+++ b/components/migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrator",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "Утилита миграции данных между версиями",
   "private": true,
   "type": "module",

--- a/components/migrator/package.json
+++ b/components/migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrator",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "Утилита миграции данных между версиями",
   "private": true,
   "type": "module",

--- a/components/notifications/package.json
+++ b/components/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/notifications",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "description": "Библиотека типобезопасных workflow-уведомлений для Novu",
   "type": "module",
   "private": false,

--- a/components/notifications/package.json
+++ b/components/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/notifications",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "description": "Библиотека типобезопасных workflow-уведомлений для Novu",
   "type": "module",
   "private": false,

--- a/components/parser/package-lock.json
+++ b/components/parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pkg-placeholder",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pkg-placeholder",
-      "version": "2026.4.24-2",
+      "version": "2026.4.26-alpha-1",
       "license": "MIT",
       "devDependencies": {
         "@antfu/eslint-config": "^2.16.0",

--- a/components/parser/package-lock.json
+++ b/components/parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pkg-placeholder",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pkg-placeholder",
-      "version": "2026.4.26-alpha-1",
+      "version": "2026.4.26-2",
       "license": "MIT",
       "devDependencies": {
         "@antfu/eslint-config": "^2.16.0",

--- a/components/parser/package.json
+++ b/components/parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/parser",
   "type": "module",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "Индексатор блокчейна через State History Plugin",

--- a/components/parser/package.json
+++ b/components/parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/parser",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "Индексатор блокчейна через State History Plugin",

--- a/components/sdk/package.json
+++ b/components/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/sdk",
   "type": "module",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "private": false,
   "packageManager": "pnpm@9.9.0",
   "description": "TypeScript SDK для работы с API кооператива",

--- a/components/sdk/package.json
+++ b/components/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/sdk",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "private": false,
   "packageManager": "pnpm@9.9.0",
   "description": "TypeScript SDK для работы с API кооператива",

--- a/components/setup/package.json
+++ b/components/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/setup",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "private": true,
   "description": "Интерактивный мастер настройки окружения",
   "main": "index.js",

--- a/components/setup/package.json
+++ b/components/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/setup",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "private": true,
   "description": "Интерактивный мастер настройки окружения",
   "main": "index.js",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "2026.4.24-2",
+  "version": "2026.4.26-alpha-1",
   "packages": [
     "components/*",
     "components/controller/src/plugins/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-2",
   "packages": [
     "components/*",
     "components/controller/src/plugins/*"


### PR DESCRIPTION
## Summary

Production release `v2026.4.26-2`. Объединяет testnet → main + lerna bump всех 15 пакетов с `2026.4.26-alpha-1` → `2026.4.26-2`.

Включает:
- 5 коммитов с dev (blago-cli фиксы конфликта на create issue, INDEX.md в корне workspace, layout `<base>/issue-requirements/<task>/<story>.md`, controller default `show_issues_requirements=false`, desktop виджет «Требования к задаче» на IssuePage, matrix-нотификации не публикуют task-stories)
- 1 коммит fix standards/FocusBar (vue-tsc TS6133)
- 2 коммита `chore(release): publish` (testnet alpha-1, production -2)

Тег `v2026.4.26-2` уже запушен на origin до PR (lerna pushed tags перед тем как push веток отклонился branch protection). После merge тег и main будут указывать на один коммит.

## Test plan
- [ ] CI зелёный
- [ ] После merge: `git fetch && git checkout main && git pull` локально, проверить что версии пакетов = `2026.4.26-2`
- [ ] Релиз пайплайн (если автоматический по тегу) собирает корректно