### PR TITLE
release: v2026.4.26-4 (production)

### DIFF
--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Та же мажорная линия pnpm, что и lockfile (lockfileVersion 6.0 = pnpm 8).
-      # Иначе `npm i -g pnpm` тянет последний pnpm и переписывает pnpm-lock.yaml → Lerna EUNCOMMIT.
+      # Жёстко прибиваем версию pnpm, которой сгенерён lockfile (lockfileVersion 9.0 = pnpm 9/10).
+      # Иначе action-setup может подтянуть другую версию и переписать pnpm-lock.yaml → Lerna EUNCOMMIT.
       - uses: pnpm/action-setup@v4
         with:
-          version: 8.15.8
+          version: 10.33.0
 
       - uses: actions/setup-node@v4
         with:

--- a/components/blago-cli/package.json
+++ b/components/blago-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/blago-cli",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "CLI синхронизации артефактов Благорост с бэкендом через @coopenomics/sdk",
   "type": "module",
   "private": true,

--- a/components/blago-cli/package.json
+++ b/components/blago-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/blago-cli",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "CLI синхронизации артефактов Благорост с бэкендом через @coopenomics/sdk",
   "type": "module",
   "private": true,

--- a/components/boot/package.json
+++ b/components/boot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/boot",
   "type": "module",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "CLI-утилита инициализации блокчейна и кооператива",

--- a/components/boot/package.json
+++ b/components/boot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/boot",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "CLI-утилита инициализации блокчейна и кооператива",

--- a/components/cleos/package.json
+++ b/components/cleos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/cleos",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "private": true,
   "description": "Обёртка над кошельком cleos для EOSIO блокчейна",
   "scripts": {

--- a/components/cleos/package.json
+++ b/components/cleos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/cleos",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "private": true,
   "description": "Обёртка над кошельком cleos для EOSIO блокчейна",
   "scripts": {

--- a/components/contracts/package.json
+++ b/components/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/contracts",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/components/contracts/package.json
+++ b/components/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/contracts",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/components/controller/package-lock.json
+++ b/components/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-nodejs-express-app",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-nodejs-express-app",
-      "version": "2026.4.26-alpha-3",
+      "version": "2026.4.26-4",
       "license": "MIT",
       "dependencies": {
         "@a2seven/yoo-checkout": "^1.1.4",

--- a/components/controller/package-lock.json
+++ b/components/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-nodejs-express-app",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-nodejs-express-app",
-      "version": "2026.4.26-alpha-1",
+      "version": "2026.4.26-alpha-3",
       "license": "MIT",
       "dependencies": {
         "@a2seven/yoo-checkout": "^1.1.4",

--- a/components/controller/package.json
+++ b/components/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/controller",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "Бэкенд GraphQL API кооператива на NestJS",
   "private": true,
   "bin": "bin/createNodejsApp.js",

--- a/components/controller/package.json
+++ b/components/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/controller",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "Бэкенд GraphQL API кооператива на NestJS",
   "private": true,
   "bin": "bin/createNodejsApp.js",

--- a/components/controller/src/extensions/capital/application/services/generation.service.ts
+++ b/components/controller/src/extensions/capital/application/services/generation.service.ts
@@ -710,8 +710,15 @@ export class GenerationService {
         issueHashesToFilter
       );
 
+      // Если задачные требования выключены, отфильтровываем stories с непустым issue_hash:
+      // репозиторий выбирает по `project_hash IN (...) OR issue_hash IN (...)`, и stories,
+      // привязанные к задачам, всё равно попадают через project_hash. Их нужно убрать здесь.
+      const filteredStories = showIssuesRequirements
+        ? allStories
+        : allStories.filter((story) => !story.issue_hash || story.issue_hash.trim() === '');
+
       // Убираем дубликаты (на случай если одна история относится к нескольким проектам)
-      const uniqueStories = allStories.filter(
+      const uniqueStories = filteredStories.filter(
         (story, index, self) => index === self.findIndex((s) => s.story_hash === story.story_hash)
       );
 

--- a/components/cooptypes/package.json
+++ b/components/cooptypes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cooptypes",
   "type": "module",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "Shared TypeScript типы и интерфейсы экосистемы кооперативов",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/cooptypes/package.json
+++ b/components/cooptypes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cooptypes",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "Shared TypeScript типы и интерфейсы экосистемы кооперативов",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/desktop/package.json
+++ b/components/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/desktop",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "Рабочий стол кооператива — Vue 3 + Quasar Framework",
   "productName": "Desktop App",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",

--- a/components/desktop/package.json
+++ b/components/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/desktop",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "Рабочий стол кооператива — Vue 3 + Quasar Framework",
   "productName": "Desktop App",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",

--- a/components/docs/package.json
+++ b/components/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/docs",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "description": "Документация для монорепозитория",

--- a/components/docs/package.json
+++ b/components/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/docs",
   "type": "module",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "description": "Документация для монорепозитория",

--- a/components/factory/package.json
+++ b/components/factory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/factory",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "Фабрика юридических документов кооператива",
   "author": "Alex Ant <chairman.voskhod@gmail.com>",
   "license": "MIT",

--- a/components/factory/package.json
+++ b/components/factory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/factory",
   "type": "module",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "Фабрика юридических документов кооператива",
   "author": "Alex Ant <chairman.voskhod@gmail.com>",
   "license": "MIT",

--- a/components/inter/package.json
+++ b/components/inter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/inter",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "Контракты и DI-токены для связи расширений контроллера без прямых зависимостей",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/inter/package.json
+++ b/components/inter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/inter",
   "type": "module",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "Контракты и DI-токены для связи расширений контроллера без прямых зависимостей",
   "author": "Alex Ant <dacom.dark.sun@gmail.com>",
   "license": "MIT",

--- a/components/migrator/package.json
+++ b/components/migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrator",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "Утилита миграции данных между версиями",
   "private": true,
   "type": "module",

--- a/components/migrator/package.json
+++ b/components/migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrator",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "Утилита миграции данных между версиями",
   "private": true,
   "type": "module",

--- a/components/notifications/package.json
+++ b/components/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/notifications",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "description": "Библиотека типобезопасных workflow-уведомлений для Novu",
   "type": "module",
   "private": false,

--- a/components/notifications/package.json
+++ b/components/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/notifications",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "description": "Библиотека типобезопасных workflow-уведомлений для Novu",
   "type": "module",
   "private": false,

--- a/components/parser/package-lock.json
+++ b/components/parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pkg-placeholder",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pkg-placeholder",
-      "version": "2026.4.26-alpha-3",
+      "version": "2026.4.26-4",
       "license": "MIT",
       "devDependencies": {
         "@antfu/eslint-config": "^2.16.0",

--- a/components/parser/package-lock.json
+++ b/components/parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pkg-placeholder",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pkg-placeholder",
-      "version": "2026.4.26-alpha-1",
+      "version": "2026.4.26-alpha-3",
       "license": "MIT",
       "devDependencies": {
         "@antfu/eslint-config": "^2.16.0",

--- a/components/parser/package.json
+++ b/components/parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/parser",
   "type": "module",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "Индексатор блокчейна через State History Plugin",

--- a/components/parser/package.json
+++ b/components/parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/parser",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "private": true,
   "packageManager": "pnpm@9.0.6",
   "description": "Индексатор блокчейна через State History Plugin",

--- a/components/sdk/package.json
+++ b/components/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/sdk",
   "type": "module",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "private": false,
   "packageManager": "pnpm@9.9.0",
   "description": "TypeScript SDK для работы с API кооператива",

--- a/components/sdk/package.json
+++ b/components/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coopenomics/sdk",
   "type": "module",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "private": false,
   "packageManager": "pnpm@9.9.0",
   "description": "TypeScript SDK для работы с API кооператива",

--- a/components/setup/package.json
+++ b/components/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/setup",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "private": true,
   "description": "Интерактивный мастер настройки окружения",
   "main": "index.js",

--- a/components/setup/package.json
+++ b/components/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopenomics/setup",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "private": true,
   "description": "Интерактивный мастер настройки окружения",
   "main": "index.js",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "2026.4.26-alpha-3",
+  "version": "2026.4.26-4",
   "packages": [
     "components/*",
     "components/controller/src/plugins/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "2026.4.26-alpha-1",
+  "version": "2026.4.26-alpha-3",
   "packages": [
     "components/*",
     "components/controller/src/plugins/*"


### PR DESCRIPTION
## Summary

Production release `v2026.4.26-4`. testnet → main + lerna bump 15 пакетов до `2026.4.26-4`.

Доп.фиксы поверх предыдущего релиза:
- `12f5fa38d45` fix(capital): задачные stories реально выкидываются на странице проекта/компонента (post-filter в getStories)
- `d0ff0df649d` fix(ci/publish-packages): pnpm 8.15.8 → 10.33.0 (CI fix)
- `c…` chore(release): testnet alpha-2

Тег `v2026.4.26-4` уже на origin (lerna push до отклонения main push).

## Test plan
- [ ] CI зелёный (после фикса pnpm на 10.33.0)
- [ ] После merge: страница проекта/компонента не показывает задачные stories
- [ ] Страница задачи показывает свои требования через виджет