### PR TITLE
ci: tag-only build-contracts/docs, отвязать от push веток

### DIFF
--- a/.github/workflows/build-contracts-docs.yaml
+++ b/.github/workflows/build-contracts-docs.yaml
@@ -1,18 +1,48 @@
-# .github/workflows/trigger-coopenomics.yml
 name: Trigger Contracts Docs Deploy
 
+# Триггерит rebuild docs в coopenomics/coopenomics только по продакшн-
+# тэгам на main. Раньше дёргался на каждый push в dev/testnet/main/capital,
+# теперь — только формальный релиз (без -alpha/-beta/-rc/-test).
 on:
   push:
-    branches: [dev, testnet, main, capital] # или когда нужно триггерить
+    tags: ['v*']
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_trigger: ${{ steps.check.outputs.should_trigger }}
+    steps:
+      - name: Checkout (для git branch --contains)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gate — main + non-alpha
+        id: check
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" =~ -(alpha|beta|rc|test) ]]; then
+            echo "Тэг $TAG — pre-release, docs deploy не дёргаем"
+            echo "should_trigger=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! git branch -r --contains "${{ github.sha }}" | grep -qE "^[[:space:]]*origin/main$"; then
+            echo "Тэг $TAG не на main — docs deploy не дёргаем"
+            echo "should_trigger=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Тэг $TAG — продакшн релиз на main, дёргаем coopenomics"
+          echo "should_trigger=true" >> "$GITHUB_OUTPUT"
+
   trigger-coopenomics:
+    needs: gate
+    if: needs.gate.outputs.should_trigger == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Coopenomics deployment
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.COOPENOMICS_PAT }}
-          repository: coopenomics/coopenomics # укажи правильный owner/repo
+          repository: coopenomics/coopenomics
           event-type: deploy_from_mono
           client-payload: '{"repository": "${{ github.repository }}", "sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "actor": "${{ github.actor }}"}'

--- a/.github/workflows/build-contracts.yaml
+++ b/.github/workflows/build-contracts.yaml
@@ -28,15 +28,12 @@ name: Build contracts container
 #   TELEGRAM_BOT_TOKEN  / TELEGRAM_CHAT_ID — уведомления
 
 on:
-  push:
-    branches: [dev, testnet, main]
-    paths:
-      - 'components/contracts/cpp/**'
-      - 'components/contracts/CMakeLists.txt'
-      - 'components/contracts/build.sh'
-      - 'components/contracts/build-all.sh'
-      - 'components/contracts/docker/**'
-      - '.github/workflows/build-contracts.yaml'
+  # Только ручной запуск. Тэги (релизы) обрабатывает release.yaml,
+  # который собирает контракты атомарно вместе с контейнерами и
+  # webhook'ом — отдельная сборка по push'у в ветку только мешает
+  # (две параллельные сборки на каждый release-bump). Здесь оставляем
+  # workflow_dispatch для ручной пересборки `dicoop/contracts:<branch>`
+  # (например, чтобы прокатить wasm на dev-ноду без релизного тэга).
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,16 +1,42 @@
 name: Publish Docs
 
+# Публикация только по продакшн-тэгам, лежащим на main (без -alpha/-beta/-rc/-test).
+# Раньше триггерилось на каждый push в main/testnet/dev/reports/marketplace2 →
+# docs пересобирались по 5+ раз в день впустую. Теперь — только релиз.
 on:
   push:
-    branches:
-      - main
-      - testnet
-      - dev
-      - reports
-      - marketplace2
+    tags: ['v*']
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - name: Checkout (для git branch --contains)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gate — main + non-alpha
+        id: check
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" =~ -(alpha|beta|rc|test) ]]; then
+            echo "Тэг $TAG — pre-release, docs не публикуем"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! git branch -r --contains "${{ github.sha }}" | grep -qE "^[[:space:]]*origin/main$"; then
+            echo "Тэг $TAG не на main — docs не публикуем"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Тэг $TAG — продакшн релиз на main, публикуем docs"
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
   build-and-publish-docs:
+    needs: gate
+    if: needs.gate.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Что

- \`build-contracts.yaml\` — был \`push: branches: [dev, testnet, main]\` + \`paths\`, теперь только \`workflow_dispatch\`. Тэги атомарно собирает \`release.yaml\`. Останется ручной триггер для отладочных пересборок \`dicoop/contracts:<branch>\` без релиза.
- \`publish-docs.yaml\` — был \`push: branches: [main, testnet, dev, reports, marketplace2]\`, теперь \`push: tags: ['v*']\` + gate-job, пропускающий только продакшн-тэги (без \`-alpha/-beta/-rc/-test\`) на main.
- \`build-contracts-docs.yaml\` (Trigger Coopenomics) — аналогично docs.

## Почему

После атомарного \`release.yaml\` (PR #366) build-contracts на push веток просто крутил вторую параллельную сборку при каждом \`chore(release): publish\`. Docs пересобирались по 5+ раз в день впустую — публикуем один раз на финальный релиз.

## Test plan
- [ ] PR проходит CI
- [ ] После merge: \`chore(release)\` коммит больше не запускает build-contracts
- [ ] alpha-bump — release.yaml собирает контракты, docs не публикуются
- [ ] прод-bump на main — release.yaml + publish-docs + build-contracts-docs запускаются
- [ ] \`gh workflow run "Build contracts container" -r dev\` всё ещё работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)