### PR TITLE
feat(cpp-registry): Story 1.2 — coop_cpp_registry + post-install hook market

### DIFF
--- a/components/controller/src/app.module.ts
+++ b/components/controller/src/app.module.ts
@@ -44,6 +44,7 @@ import { RegistrationDomainModule } from './domain/registration/registration-dom
 import { OnboardingDomainModule } from './domain/onboarding/onboarding-domain.module';
 import { TokenDomainModule } from './domain/token/token-domain.module';
 import { MutationLogDomainModule } from './domain/mutation-log/mutation-log-domain.module';
+import { CppRegistryDomainModule } from './domain/cpp-registry/cpp-registry-domain.module';
 
 // Application modules
 import { AccountModule } from './application/account/account.module';
@@ -80,6 +81,7 @@ import { SearchModule } from './application/search/search.module';
 import { MutationLoggingInterceptor } from './application/common/interceptors/mutation-logging.interceptor';
 import { MarketplacePluginModule } from './extensions/marketplace/marketplace-extension.module';
 import { MarketplaceCardsModule } from './extensions/marketplace-cards/marketplace-cards.module';
+import { CppRegistryModule } from './application/cpp-registry/cpp-registry.module';
 
 @Module({
   imports: [
@@ -131,6 +133,7 @@ import { MarketplaceCardsModule } from './extensions/marketplace-cards/marketpla
     SettingsInfrastructureModule,
     TokenDomainModule,
     MutationLogDomainModule,
+    CppRegistryDomainModule,
     // Application modules
     AccountModule,
     AgreementModule,
@@ -163,6 +166,7 @@ import { MarketplaceCardsModule } from './extensions/marketplace-cards/marketpla
     RegistrationModule,
     OnboardingApplicationModule,
     SearchModule,
+    CppRegistryModule,
     // Marketplace extensions
     MarketplacePluginModule,
     MarketplaceCardsModule,

--- a/components/controller/src/application/cpp-registry/cpp-registry.module.ts
+++ b/components/controller/src/application/cpp-registry/cpp-registry.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CppRegistryDomainModule } from '~/domain/cpp-registry/cpp-registry-domain.module';
+import { CppRegistryResolver } from './resolvers/cpp-registry.resolver';
+
+@Module({
+  imports: [CppRegistryDomainModule],
+  providers: [CppRegistryResolver],
+})
+export class CppRegistryModule {}

--- a/components/controller/src/application/cpp-registry/dto/cpp-registry-entry.dto.ts
+++ b/components/controller/src/application/cpp-registry/dto/cpp-registry-entry.dto.ts
@@ -1,0 +1,32 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+import type { CppRegistryEntryDomainEntity } from '~/domain/cpp-registry/entities/cpp-registry-entry.entity';
+
+@ObjectType('CppRegistryEntry', {
+  description: 'Запись реестра ЦПП-шаблонов кооператива (Story 1.2 / Locked Decision L8).',
+})
+export class CppRegistryEntryDTO {
+  @Field(() => Int, {
+    description:
+      'document_registry_id template-документа в платформенном document registry (наполняется Story 1.7).',
+  })
+  template_document_registry_id!: number;
+
+  @Field(() => String, {
+    description: 'Имя расширения, которому принадлежит шаблон (например, "market").',
+  })
+  required_for_extension!: string;
+
+  @Field(() => Boolean, {
+    description:
+      'true → fallback FR43a (захардкоженная пара template-документов, MVP без UI конструктора ЦПП).',
+  })
+  mvp_hardcoded!: boolean;
+
+  static fromDomain(entry: CppRegistryEntryDomainEntity): CppRegistryEntryDTO {
+    const dto = new CppRegistryEntryDTO();
+    dto.template_document_registry_id = entry.template_document_registry_id;
+    dto.required_for_extension = entry.required_for_extension;
+    dto.mvp_hardcoded = entry.mvp_hardcoded;
+    return dto;
+  }
+}

--- a/components/controller/src/application/cpp-registry/resolvers/cpp-registry.resolver.ts
+++ b/components/controller/src/application/cpp-registry/resolvers/cpp-registry.resolver.ts
@@ -1,0 +1,24 @@
+import { Resolver, Query } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { GqlJwtAuthGuard } from '~/application/auth/guards/graphql-jwt-auth.guard';
+import { RolesGuard } from '~/application/auth/guards/roles.guard';
+import { AuthRoles } from '~/application/auth/decorators/auth.decorator';
+import { CppRegistryDomainService } from '~/domain/cpp-registry/services/cpp-registry-domain.service';
+import { CppRegistryEntryDTO } from '../dto/cpp-registry-entry.dto';
+
+@Resolver(() => CppRegistryEntryDTO)
+export class CppRegistryResolver {
+  constructor(private readonly service: CppRegistryDomainService) {}
+
+  @Query(() => [CppRegistryEntryDTO], {
+    name: 'cppRegistry',
+    description:
+      'Реестр ЦПП-шаблонов кооператива — связки template_document_registry_id ↔ расширение (Story 1.2).',
+  })
+  @UseGuards(GqlJwtAuthGuard, RolesGuard)
+  @AuthRoles(['chairman', 'member'])
+  async cppRegistry(): Promise<CppRegistryEntryDTO[]> {
+    const entries = await this.service.findAll();
+    return entries.map(CppRegistryEntryDTO.fromDomain);
+  }
+}

--- a/components/controller/src/domain/cpp-registry/cpp-registry-domain.module.ts
+++ b/components/controller/src/domain/cpp-registry/cpp-registry-domain.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CppRegistryDomainService } from './services/cpp-registry-domain.service';
+
+@Module({
+  imports: [],
+  providers: [CppRegistryDomainService],
+  exports: [CppRegistryDomainService],
+})
+export class CppRegistryDomainModule {}

--- a/components/controller/src/domain/cpp-registry/entities/cpp-registry-entry.entity.ts
+++ b/components/controller/src/domain/cpp-registry/entities/cpp-registry-entry.entity.ts
@@ -1,0 +1,36 @@
+/**
+ * Запись `coop_cpp_registry` per-cooperative — связка ЦПП-шаблона из платформенного
+ * document registry с расширением controller'а.
+ *
+ * Story 1.2 (epics.md, Эпик 1) + Locked Decisions L8/L9.
+ *
+ * Каждое расширение, у которого есть ЦПП-документ для онбординга, кладёт в
+ * реестр одну запись с `template_document_registry_id` (из платформенного
+ * document registry, см. AR33/Story 1.7) и `required_for_extension`. Stories
+ * 1.4/1.9/1.11 читают её, чтобы знать, какой template подписан/подписывается.
+ *
+ * `mvp_hardcoded: true` — индикатор fallback'а FR43a (захардкоженная пара
+ * template'ов, без UI конструктора ЦПП в admin-столе MVP). После Phase 2
+ * (динамический конструктор ЦПП в core) этот флаг переключится в `false`.
+ */
+export class CppRegistryEntryDomainEntity {
+  public template_document_registry_id!: number;
+  public required_for_extension!: string;
+  public mvp_hardcoded!: boolean;
+  public created_at?: Date;
+  public updated_at?: Date;
+
+  constructor(props: {
+    template_document_registry_id: number;
+    required_for_extension: string;
+    mvp_hardcoded: boolean;
+    created_at?: Date;
+    updated_at?: Date;
+  }) {
+    this.template_document_registry_id = props.template_document_registry_id;
+    this.required_for_extension = props.required_for_extension;
+    this.mvp_hardcoded = props.mvp_hardcoded;
+    this.created_at = props.created_at;
+    this.updated_at = props.updated_at;
+  }
+}

--- a/components/controller/src/domain/cpp-registry/repositories/cpp-registry.repository.ts
+++ b/components/controller/src/domain/cpp-registry/repositories/cpp-registry.repository.ts
@@ -1,0 +1,16 @@
+import type { CppRegistryEntryDomainEntity } from '../entities/cpp-registry-entry.entity';
+
+export const CPP_REGISTRY_REPOSITORY = Symbol('CPP_REGISTRY_REPOSITORY');
+
+/**
+ * Репозиторий реестра ЦПП-шаблонов кооператива (Story 1.2).
+ *
+ * Контракт идемпотентного upsert по `required_for_extension` — повторная
+ * установка расширения не должна дублировать запись (AC Story 1.2).
+ */
+export interface CppRegistryRepository {
+  upsertByExtension(entry: CppRegistryEntryDomainEntity): Promise<CppRegistryEntryDomainEntity>;
+  findByExtension(extensionName: string): Promise<CppRegistryEntryDomainEntity | null>;
+  findAll(): Promise<CppRegistryEntryDomainEntity[]>;
+  deleteByExtension(extensionName: string): Promise<boolean>;
+}

--- a/components/controller/src/domain/cpp-registry/services/cpp-registry-domain.service.ts
+++ b/components/controller/src/domain/cpp-registry/services/cpp-registry-domain.service.ts
@@ -1,0 +1,44 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { WinstonLoggerService } from '~/application/logger/logger-app.service';
+import {
+  CPP_REGISTRY_REPOSITORY,
+  type CppRegistryRepository,
+} from '../repositories/cpp-registry.repository';
+import { CppRegistryEntryDomainEntity } from '../entities/cpp-registry-entry.entity';
+
+@Injectable()
+export class CppRegistryDomainService {
+  constructor(
+    @Inject(CPP_REGISTRY_REPOSITORY) private readonly repository: CppRegistryRepository,
+    private readonly logger: WinstonLoggerService
+  ) {
+    this.logger.setContext(CppRegistryDomainService.name);
+  }
+
+  /**
+   * Идемпотентный upsert записи реестра. `extensionName` — естественный ключ
+   * (один template per extension в MVP); повторный вызов с тем же
+   * `extensionName` обновит `template_document_registry_id`/`mvp_hardcoded`,
+   * не создаёт дубликат.
+   */
+  async register(input: {
+    template_document_registry_id: number;
+    required_for_extension: string;
+    mvp_hardcoded: boolean;
+  }): Promise<CppRegistryEntryDomainEntity> {
+    const entry = new CppRegistryEntryDomainEntity(input);
+    const saved = await this.repository.upsertByExtension(entry);
+    this.logger.info(
+      `[CPP_REGISTRY] upsert ${input.required_for_extension} → template_document_registry_id=${input.template_document_registry_id} (mvp_hardcoded=${input.mvp_hardcoded})`
+    );
+    return saved;
+  }
+
+  async findByExtension(extensionName: string): Promise<CppRegistryEntryDomainEntity | null> {
+    return this.repository.findByExtension(extensionName);
+  }
+
+  async findAll(): Promise<CppRegistryEntryDomainEntity[]> {
+    return this.repository.findAll();
+  }
+}

--- a/components/controller/src/extensions/marketplace/constants/marketplace-template-registry.ts
+++ b/components/controller/src/extensions/marketplace/constants/marketplace-template-registry.ts
@@ -1,0 +1,15 @@
+/**
+ * `document_registry_id` template'ов оферт «Стола заказов» в платформенном
+ * document registry (наполняется Story 1.7 как one-time platform setup).
+ *
+ * MVP-fallback (FR43a): пара (Положение ЦПП, Оферта присоединения к ЦПП) —
+ * захардкоженный template из document factory, без UI конструктора ЦПП в
+ * admin-столе. Пока Story 1.7 не выполнена, ID = 0 → post-install hook
+ * расширения marketplace не пишет запись в `coop_cpp_registry` и оставляет
+ * warn-лог.
+ *
+ * После Story 1.7 — заменить 0 на реальный `document_registry_id` template'а
+ * (либо вынести в config / cooptypes-registry, как `Cooperative.Registry.*`
+ * в Благоросте).
+ */
+export const MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0;

--- a/components/controller/src/extensions/marketplace/marketplace-extension.module.ts
+++ b/components/controller/src/extensions/marketplace/marketplace-extension.module.ts
@@ -11,6 +11,9 @@ import { config } from '~/config';
 import { IConfig, defaultConfig, Schema } from './types';
 import { MarketplaceExtensionDomainModule } from './domain/marketplace-domain.module';
 import { MarketplaceExtensionApplicationModule } from './application/marketplace-application.module';
+import { CppRegistryDomainModule } from '~/domain/cpp-registry/cpp-registry-domain.module';
+import { CppRegistryDomainService } from '~/domain/cpp-registry/services/cpp-registry-domain.service';
+import { MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID } from './constants/marketplace-template-registry';
 
 /**
  * Optional-инжектируемый порт файлового хранилища. Имя расширения marketplace
@@ -29,6 +32,7 @@ export class MarketplacePlugin extends BaseExtModule {
   constructor(
     @Inject(EXTENSION_REPOSITORY) private readonly extensionRepository: ExtensionDomainRepository<IConfig>,
     private readonly logger: WinstonLoggerService,
+    private readonly cppRegistryService: CppRegistryDomainService,
     @Optional()
     @Inject(MARKETPLACE_FILE_STORAGE_PORT)
     private readonly fileStorage: IMarketplaceFileStoragePort | null = null
@@ -56,8 +60,34 @@ export class MarketplacePlugin extends BaseExtModule {
     };
 
     await this.initBucket();
+    await this.registerCppTemplate();
 
     this.logger.info('marketplace-extension готов');
+  }
+
+  /**
+   * Post-install hook (Story 1.2 / Locked Decisions L8/L9): связывает
+   * расширение `market` с template-документом оферты ЦПП в платформенном
+   * document registry через `coop_cpp_registry`. Идемпотентен — повторная
+   * установка не дублирует запись.
+   *
+   * Пока Story 1.7 не выполнена (one-time platform setup), константа
+   * `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID` = 0 → пишем warn и не создаём
+   * запись (Stories 1.4/1.9/1.11 fallback'нут на отсутствие template'а).
+   */
+  private async registerCppTemplate(): Promise<void> {
+    if (MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID <= 0) {
+      this.logger.warn(
+        'MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID не задан (Story 1.7 ещё не выполнена) — запись в coop_cpp_registry пропущена'
+      );
+      return;
+    }
+
+    await this.cppRegistryService.register({
+      template_document_registry_id: MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID,
+      required_for_extension: this.name,
+      mvp_hardcoded: true,
+    });
   }
 
   /**
@@ -85,6 +115,7 @@ export class MarketplacePlugin extends BaseExtModule {
   imports: [
     MarketplaceExtensionDomainModule, // Доменный слой (включает инфраструктуру через DIP)
     MarketplaceExtensionApplicationModule, // Слой приложения (GraphQL резолверы и сервисы)
+    CppRegistryDomainModule, // Story 1.2 — post-install hook регистрирует template ЦПП в coop_cpp_registry
   ],
   providers: [MarketplacePlugin],
   exports: [MarketplacePlugin],

--- a/components/controller/src/infrastructure/database/typeorm/entities/cpp-registry-entry.typeorm-entity.ts
+++ b/components/controller/src/infrastructure/database/typeorm/entities/cpp-registry-entry.typeorm-entity.ts
@@ -1,0 +1,29 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+export const EntityName = 'coop_cpp_registry';
+
+@Entity(EntityName)
+@Index(`uq_${EntityName}_required_for_extension`, ['required_for_extension'], { unique: true })
+export class CppRegistryEntryTypeormEntity {
+  static getTableName(): string {
+    return EntityName;
+  }
+
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'integer' })
+  template_document_registry_id!: number;
+
+  @Column({ type: 'varchar', length: 64 })
+  required_for_extension!: string;
+
+  @Column({ type: 'boolean', default: true })
+  mvp_hardcoded!: boolean;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  created_at!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updated_at!: Date;
+}

--- a/components/controller/src/infrastructure/database/typeorm/repositories/cpp-registry.typeorm-repository.ts
+++ b/components/controller/src/infrastructure/database/typeorm/repositories/cpp-registry.typeorm-repository.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { CppRegistryRepository } from '~/domain/cpp-registry/repositories/cpp-registry.repository';
+import { CppRegistryEntryDomainEntity } from '~/domain/cpp-registry/entities/cpp-registry-entry.entity';
+import { CppRegistryEntryTypeormEntity } from '../entities/cpp-registry-entry.typeorm-entity';
+
+@Injectable()
+export class CppRegistryTypeormRepository implements CppRegistryRepository {
+  constructor(
+    @InjectRepository(CppRegistryEntryTypeormEntity)
+    private readonly repo: Repository<CppRegistryEntryTypeormEntity>
+  ) {}
+
+  async upsertByExtension(entry: CppRegistryEntryDomainEntity): Promise<CppRegistryEntryDomainEntity> {
+    const existing = await this.repo.findOne({
+      where: { required_for_extension: entry.required_for_extension },
+    });
+
+    if (existing) {
+      existing.template_document_registry_id = entry.template_document_registry_id;
+      existing.mvp_hardcoded = entry.mvp_hardcoded;
+      const saved = await this.repo.save(existing);
+      return CppRegistryTypeormRepository.toDomain(saved);
+    }
+
+    const created = this.repo.create({
+      template_document_registry_id: entry.template_document_registry_id,
+      required_for_extension: entry.required_for_extension,
+      mvp_hardcoded: entry.mvp_hardcoded,
+    });
+    const saved = await this.repo.save(created);
+    return CppRegistryTypeormRepository.toDomain(saved);
+  }
+
+  async findByExtension(extensionName: string): Promise<CppRegistryEntryDomainEntity | null> {
+    const row = await this.repo.findOne({ where: { required_for_extension: extensionName } });
+    return row ? CppRegistryTypeormRepository.toDomain(row) : null;
+  }
+
+  async findAll(): Promise<CppRegistryEntryDomainEntity[]> {
+    const rows = await this.repo.find();
+    return rows.map(CppRegistryTypeormRepository.toDomain);
+  }
+
+  async deleteByExtension(extensionName: string): Promise<boolean> {
+    const result = await this.repo.delete({ required_for_extension: extensionName });
+    return (result.affected ?? 0) > 0;
+  }
+
+  private static toDomain(row: CppRegistryEntryTypeormEntity): CppRegistryEntryDomainEntity {
+    return new CppRegistryEntryDomainEntity({
+      template_document_registry_id: row.template_document_registry_id,
+      required_for_extension: row.required_for_extension,
+      mvp_hardcoded: row.mvp_hardcoded,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    });
+  }
+}

--- a/components/controller/src/infrastructure/database/typeorm/typeorm.module.ts
+++ b/components/controller/src/infrastructure/database/typeorm/typeorm.module.ts
@@ -87,6 +87,9 @@ import { UserWalletTypeormRepository } from './repositories/user-wallet.typeorm-
 import { UserWalletDeltaMapper } from './blockchain/mappers/user-wallet-delta.mapper';
 import { UserWalletSyncService } from './blockchain/services/user-wallet-sync.service';
 import { UserWalletIndexInitializer } from './blockchain/services/user-wallet-index-initializer.service';
+import { CppRegistryEntryTypeormEntity } from './entities/cpp-registry-entry.typeorm-entity';
+import { CPP_REGISTRY_REPOSITORY } from '~/domain/cpp-registry/repositories/cpp-registry.repository';
+import { CppRegistryTypeormRepository } from './repositories/cpp-registry.typeorm-repository';
 
 @Global()
 @Module({
@@ -134,6 +137,7 @@ import { UserWalletIndexInitializer } from './blockchain/services/user-wallet-in
       ProgramWalletTypeormEntity,
       UserAgreementTypeormEntity,
       UserWalletTypeormEntity,
+      CppRegistryEntryTypeormEntity,
     ]),
   ],
   providers: [
@@ -249,6 +253,11 @@ import { UserWalletIndexInitializer } from './blockchain/services/user-wallet-in
     UserWalletDeltaMapper,
     UserWalletSyncService,
     UserWalletIndexInitializer,
+    // CppRegistry компоненты (Story 1.2)
+    {
+      provide: CPP_REGISTRY_REPOSITORY,
+      useClass: CppRegistryTypeormRepository,
+    },
     EntityVersionRepository,
     EntityVersioningService,
   ],
@@ -284,6 +293,7 @@ import { UserWalletIndexInitializer } from './blockchain/services/user-wallet-in
     USER_WALLET_REPOSITORY,
     UserWalletDeltaMapper,
     UserWalletSyncService,
+    CPP_REGISTRY_REPOSITORY,
     EntityVersionRepository,
     EntityVersioningService,
   ],

--- a/components/controller/tests/unit/cpp-registry/cpp-registry-domain-service.test.ts
+++ b/components/controller/tests/unit/cpp-registry/cpp-registry-domain-service.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit-тесты CppRegistryDomainService.register (Story 1.2).
+ *
+ * AC: «при повторной установке запись не дублируется (upsert)».
+ *
+ * Покрываем:
+ *   (a) первый вызов register → upsertByExtension вызван с теми же данными;
+ *   (b) повторный вызов register (имитация re-install) → upsertByExtension
+ *       вызван второй раз с тем же `required_for_extension` (репозиторий
+ *       обновит существующую запись, не создаст новую — идемпотентность);
+ *   (c) логирование информации о записи.
+ */
+
+import { CppRegistryDomainService } from '~/domain/cpp-registry/services/cpp-registry-domain.service';
+import { CppRegistryEntryDomainEntity } from '~/domain/cpp-registry/entities/cpp-registry-entry.entity';
+
+const makeLogger = () =>
+  ({
+    setContext: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as any);
+
+const makeRepo = () =>
+  ({
+    upsertByExtension: jest.fn().mockImplementation(async (entry: CppRegistryEntryDomainEntity) => entry),
+    findByExtension: jest.fn(),
+    findAll: jest.fn().mockResolvedValue([]),
+    deleteByExtension: jest.fn(),
+  } as any);
+
+describe('CppRegistryDomainService.register', () => {
+  const input = {
+    template_document_registry_id: 996,
+    required_for_extension: 'market',
+    mvp_hardcoded: true,
+  };
+
+  it('вызывает upsertByExtension с переданными данными и логирует upsert', async () => {
+    const repo = makeRepo();
+    const logger = makeLogger();
+    const service = new CppRegistryDomainService(repo, logger);
+
+    const saved = await service.register(input);
+
+    expect(repo.upsertByExtension).toHaveBeenCalledTimes(1);
+    const calledWith: CppRegistryEntryDomainEntity = repo.upsertByExtension.mock.calls[0][0];
+    expect(calledWith.template_document_registry_id).toBe(996);
+    expect(calledWith.required_for_extension).toBe('market');
+    expect(calledWith.mvp_hardcoded).toBe(true);
+
+    expect(saved.required_for_extension).toBe('market');
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('[CPP_REGISTRY] upsert market → template_document_registry_id=996')
+    );
+  });
+
+  it('повторный register с тем же extension вызывает upsertByExtension снова (идемпотентно — repo обновит, не задублирует)', async () => {
+    const repo = makeRepo();
+    const service = new CppRegistryDomainService(repo, makeLogger());
+
+    await service.register(input);
+    await service.register({ ...input, template_document_registry_id: 1000 });
+
+    expect(repo.upsertByExtension).toHaveBeenCalledTimes(2);
+    const firstCall: CppRegistryEntryDomainEntity = repo.upsertByExtension.mock.calls[0][0];
+    const secondCall: CppRegistryEntryDomainEntity = repo.upsertByExtension.mock.calls[1][0];
+    expect(firstCall.required_for_extension).toBe(secondCall.required_for_extension);
+    expect(firstCall.template_document_registry_id).toBe(996);
+    expect(secondCall.template_document_registry_id).toBe(1000);
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-plugin-initialize.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-plugin-initialize.test.ts
@@ -26,11 +26,18 @@ const makeRepo = (record: any = { name: 'market', config: {}, enabled: true }) =
     findByName: jest.fn().mockResolvedValue(record),
   } as any);
 
+const makeCppRegistry = () =>
+  ({
+    register: jest.fn().mockResolvedValue({}),
+    findByExtension: jest.fn(),
+    findAll: jest.fn(),
+  } as any);
+
 describe('MarketplacePlugin.initialize', () => {
   it('пишет warn о fallback и продолжает install, если file-storage не подключён', async () => {
     const logger = makeLogger();
     const repo = makeRepo();
-    const plugin = new MarketplacePlugin(repo, logger, null);
+    const plugin = new MarketplacePlugin(repo, logger, makeCppRegistry(), null);
 
     await plugin.initialize();
 
@@ -47,7 +54,7 @@ describe('MarketplacePlugin.initialize', () => {
     const logger = makeLogger();
     const repo = makeRepo();
     const fileStorage = { ensureBucket: jest.fn().mockResolvedValue(undefined) };
-    const plugin = new MarketplacePlugin(repo, logger, fileStorage);
+    const plugin = new MarketplacePlugin(repo, logger, makeCppRegistry(), fileStorage);
 
     await plugin.initialize();
 
@@ -61,13 +68,26 @@ describe('MarketplacePlugin.initialize', () => {
   it('бросает «Конфиг не найден» если в БД нет записи market', async () => {
     const logger = makeLogger();
     const repo = makeRepo(null);
-    const plugin = new MarketplacePlugin(repo, logger, null);
+    const plugin = new MarketplacePlugin(repo, logger, makeCppRegistry(), null);
 
     await expect(plugin.initialize()).rejects.toThrow('Конфиг не найден');
   });
 
   it('расширение зарегистрировано под именем `market` (совпадает с ключом AppRegistry)', () => {
-    const plugin = new MarketplacePlugin(makeRepo(), makeLogger(), null);
+    const plugin = new MarketplacePlugin(makeRepo(), makeLogger(), makeCppRegistry(), null);
     expect(plugin.name).toBe('market');
+  });
+
+  it('пропускает регистрацию в coop_cpp_registry при placeholder MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID=0 (warn-лог)', async () => {
+    const logger = makeLogger();
+    const cppRegistry = makeCppRegistry();
+    const plugin = new MarketplacePlugin(makeRepo(), logger, cppRegistry, null);
+
+    await plugin.initialize();
+
+    expect(cppRegistry.register).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID не задан')
+    );
   });
 });


### PR DESCRIPTION
## Summary

Story 1.2 эпика 1 (компонент `3-minimalnyy-produkt` проекта «Стол заказов» MVP).
Создаёт per-cooperative реестр ЦПП-шаблонов `coop_cpp_registry` (core-домен) и post-install hook расширения `market`, который пишет туда связку `template_document_registry_id ↔ required_for_extension`. Stories 1.4/1.9/1.11 будут читать эту запись для онбординг-проверок.

## Изменения

**Core-домен (новый):** `src/domain/cpp-registry/`
- `CppRegistryEntryDomainEntity` — plain class.
- `CppRegistryRepository` интерфейс + `CPP_REGISTRY_REPOSITORY` token.
- `CppRegistryDomainService.register` — идемпотентный upsert через `upsertByExtension`.
- `CppRegistryDomainModule` — экспортирует service.

**TypeORM-инфраструктура:** `src/infrastructure/database/typeorm/`
- `CppRegistryEntryTypeormEntity` — таблица `coop_cpp_registry`, unique-index `uq_coop_cpp_registry_required_for_extension` гарантирует идемпотентность.
- `CppRegistryTypeormRepository` — `upsertByExtension` через `findOne + save / create + save`.
- `typeorm.module.ts` — entity в `forFeature` + bind `CPP_REGISTRY_REPOSITORY → CppRegistryTypeormRepository` + export.

**Application:** `src/application/cpp-registry/`
- `CppRegistryEntryDTO` (`@ObjectType('CppRegistryEntry')`, `fromDomain`).
- `CppRegistryResolver` — Query `cppRegistry` (AuthRoles `['chairman','member']`).
- `CppRegistryModule` импортирует domain.
- Регистрация в `app.module.ts` (`CppRegistryDomainModule` + `CppRegistryModule`).

**Marketplace расширение:**
- `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0` placeholder в `extensions/marketplace/constants/marketplace-template-registry.ts` (наполняется Story 1.7).
- `MarketplacePlugin.initialize()` после `initBucket` зовёт `registerCppTemplate()`: при ID > 0 пишет запись через `CppRegistryDomainService`, при ID ≤ 0 — `warn`-лог и пропуск (Story 1.7 ещё не выполнена).
- В `MarketplacePluginModule.imports` добавлен `CppRegistryDomainModule`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — 0 ошибок.
- [x] `tests/unit/cpp-registry/cpp-registry-domain-service.test.ts` — 2 кейса (upsert + повторный register не дублирует).
- [x] `tests/unit/marketplace/marketplace-plugin-initialize.test.ts` — обновлён под новый конструктор; 5 кейсов (4 от Story 1.1 + 1 новый «ID=0 → warn, register не вызван»).
- [x] `tests/unit/appstore/extension-interactor-install-rollback.test.ts` — 3 кейса от Story 1.1 продолжают проходить.
- [ ] После merge в `marketplace2` — поднять controller в dev-окружении, выполнить `installExtension({name:"market"})` и проверить наличие записи в `coop_cpp_registry` (только когда константа > 0; пока Story 1.7 не сделана — запись не создаётся, warn в логах).
- [ ] GraphQL: `query { cppRegistry { template_document_registry_id required_for_extension mvp_hardcoded } }` под chairman-токеном → возвращает либо `[]`, либо запись (зависит от константы).

## Тех-долги

1. `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0` — placeholder; будет заменён в Story 1.7. Альтернативно — вынести в `cooptypes` `Cooperative.Registry.MarketplaceOfferTemplate.registry_id` по аналогии с Благоростом.
2. Рыбы документов ЦПП (положение + оферта) — параллельный TODO, блокирует Stories 1.7/1.9/1.11.
3. Дублирование импорта `MarketplacePluginModule` (в `ExtensionsModule.register` и напрямую в `AppModule`) — наследие Story 1.1; NestJS singleton'ит, поведение корректное. Унификация — отдельный технический PR.

Ref: `_blago/.../components/3-minimalnyy-produkt/_bmad-output/implementation-artifacts/spec-1-2-cpp-registry-link.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)