### PR TITLE
feat(marketplace): Story 1.9 — L1 решение совета о ЦПП (MVP-stub)

### DIFF
--- a/components/controller/src/domain/extension/extension-domain.module.ts
+++ b/components/controller/src/domain/extension/extension-domain.module.ts
@@ -12,6 +12,7 @@ import { chatcoopManagedMatrixRoomsV3Migration } from '~/extensions/chatcoop/mig
 import { chatcoopStatePgV4Migration } from '~/extensions/chatcoop/migrations/chatcoop-state-pg-v4.migration';
 import { chatcoopMessageHistoryIngestCursorV5Migration } from '~/extensions/chatcoop/migrations/chatcoop-message-history-ingest-cursor-v5.migration';
 import { marketplaceBootstrapV1Migration } from '~/extensions/marketplace/migrations/marketplace-bootstrap-v1.migration';
+import { marketplaceBootstrapV2Migration } from '~/extensions/marketplace/migrations/marketplace-bootstrap-v2.migration';
 import { WinstonLoggerService } from '~/application/logger/logger-app.service';
 
 import { ExtensionsModule } from '~/extensions/extensions.module';
@@ -56,6 +57,7 @@ export class ExtensionDomainModule {
     this.migrationService.registerMigration(chatcoopStatePgV4Migration);
     this.migrationService.registerMigration(chatcoopMessageHistoryIngestCursorV5Migration);
     this.migrationService.registerMigration(marketplaceBootstrapV1Migration);
+    this.migrationService.registerMigration(marketplaceBootstrapV2Migration);
 
     // Устанавливаем расширения по умолчанию
     await this.extensionInteractor.installDefaultApps();

--- a/components/controller/src/domain/registration/dto/agreement-registration-spec.dto.ts
+++ b/components/controller/src/domain/registration/dto/agreement-registration-spec.dto.ts
@@ -12,7 +12,7 @@ export interface AgreementRegistrationSpec {
   /**
    * Уникальный идентификатор оферты в рамках платформы.
    * Строка, потому что расширение само определяет своё пространство имён
-   * (например, 'blagorost_offer', 'generator_offer', 'order_table_offer').
+   * (например, 'blagorost_offer', 'generator_offer', 'marketplace_offer').
    */
   id: string;
 
@@ -25,8 +25,12 @@ export interface AgreementRegistrationSpec {
 
   /**
    * Тип соглашения для on-chain `agreements` (sendAgreement action).
-   * Расширение предоставляет своё значение (например 'capital' для capital,
-   * 'order_table' для Стола заказов).
+   * Должно быть валидным eosio::name (max 12 символов из [.a-z1-5], БЕЗ `_`)
+   * и существовать в `soviet::coagreements` (создаётся либо в init.cpp, либо
+   * через createprog) — иначе sndagreement/signagree падают
+   * «Соглашение указанного типа не найдено».
+   * Расширение предоставляет своё значение (например 'capital' для Capital,
+   * 'marketplace' для Стола заказов = program_id=2).
    */
   agreement_type: string;
 

--- a/components/controller/src/extensions/marketplace/application/access/marketplace-access-matrix.ts
+++ b/components/controller/src/extensions/marketplace/application/access/marketplace-access-matrix.ts
@@ -1,0 +1,107 @@
+import type { MarketplaceRole } from '../membership/marketplace-roles.mapper';
+
+/**
+ * Story 1.8: централизованная access-matrix marketplace (CASL-совместимая).
+ *
+ * Структура: `Record<MarketplaceRole, Record<Resource, Action[]>>`.
+ * `canAccess(roles, resource, action)` возвращает true, если в матрице
+ * для хотя бы одной из `roles` есть `resource` → `action` (или его
+ * квалифицированная форма).
+ *
+ * Нотации actions:
+ *   - `create`, `update`, `delete`, `read`, `cancel` — базовые action.
+ *   - `:own`        — только над объектом, владелец которого == текущий пайщик.
+ *   - `:all`        — над всеми объектами в скоупе.
+ *   - `:to-self`    — частный случай read: объекты, адресованные пайщику.
+ *   - `:own-KU`     — только в рамках КУ, председатель которого == пайщик (Эпик 2).
+ *   - `:first`      — первая подпись в multisig (Эпик 2/6).
+ *
+ * Ownership-проверка (`:own`/`:own-KU`/`:to-self`) сама matrix НЕ делает —
+ * resolver обязан верифицировать `member_id == record.owner`/`record.recipient`
+ * после прохождения guard'а. Guard отвечает за «эта роль вообще может
+ * action над resource» (capability), а не за data-uniqueness ownership.
+ *
+ * Phase 2 migration: содержимое транслируется в CASL `defineAbility`,
+ * `canAccess` подменяется на `ability.can(action, subject)` без изменения
+ * вызывающего кода (guard читает абилити через тот же интерфейс).
+ *
+ * Resources покрытие: MVP Эпик 1–4. Эпики 5–10 (АПП, гарантийный возврат,
+ * витрина, отчётность) добавят новые resources — расширение матрицы без
+ * правок resolver-ов.
+ */
+export const marketplaceAccessMatrix: Record<MarketplaceRole, Record<string, string[]>> = {
+  orderer: {
+    Order: ['create', 'read:own', 'cancel:own'],
+    Offer: ['read'],
+    KU: ['read'],
+    Vitrine: ['read'],
+  },
+  offerer: {
+    Offer: ['create:own', 'update:own', 'delete:own'],
+    Order: ['read:to-self'],
+    Shipment: ['create:own'],
+    KU: ['read'],
+  },
+  operator: {
+    Receiving: ['create', 'sign:first'],
+    Issuance: ['create', 'sign:first'],
+    Warehouse: ['read:own-KU'],
+    KU: ['read:own-KU'],
+  },
+  admin: {
+    Offer: ['moderate'],
+    KU: ['manage'],
+    Whitelist: ['manage'],
+    Vitrine: ['manage'],
+    Warehouse: ['read:all'],
+    Extension: ['configure'],
+  },
+  board_readonly: {
+    Warehouse: ['read:all'],
+    Order: ['read:all'],
+    Offer: ['read:all'],
+    Agenda: ['read'],
+  },
+  board: {
+    Agenda: ['manage'],
+    Writeoff: ['decide'],
+    Decision: ['create', 'sign'],
+  },
+};
+
+/**
+ * Проверяет, что хотя бы одна из `roles` пайщика имеет в матрице запись
+ * `resource` → `action`. Ownership-квалификаторы (`:own`/`:all`/...)
+ * матчатся буквально — это значит resolver должен передать ровно тот
+ * action, что записан в матрице (например, `'read:own'`, не `'read'`).
+ * Для проверки «может ли роль вообще читать resource в любой форме» —
+ * используйте `roleHasAnyAction(role, resource, baseAction)`.
+ */
+export function canAccess(
+  roles: MarketplaceRole[],
+  resource: string,
+  action: string
+): boolean {
+  return roles.some((role) => {
+    const resourceActions = marketplaceAccessMatrix[role]?.[resource];
+    return resourceActions?.includes(action) ?? false;
+  });
+}
+
+/**
+ * Возвращает true, если хотя бы одна роль имеет ANY action на resource
+ * с тем же базовым именем (до двоеточия). Полезно для предварительной
+ * фильтрации UI (показать ли пункт меню «Заказы», если у пайщика есть
+ * хоть какое-то `Order:read*`).
+ */
+export function roleHasAnyAction(
+  roles: MarketplaceRole[],
+  resource: string,
+  baseAction: string
+): boolean {
+  return roles.some((role) => {
+    const resourceActions = marketplaceAccessMatrix[role]?.[resource];
+    if (!resourceActions) return false;
+    return resourceActions.some((a) => a === baseAction || a.startsWith(`${baseAction}:`));
+  });
+}

--- a/components/controller/src/extensions/marketplace/application/coop-acceptance/marketplace-coop-acceptance.service.ts
+++ b/components/controller/src/extensions/marketplace/application/coop-acceptance/marketplace-coop-acceptance.service.ts
@@ -1,0 +1,114 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+
+import {
+  EXTENSION_REPOSITORY,
+  ExtensionDomainRepository,
+} from '~/domain/extension/repositories/extension-domain.repository';
+import { WinstonLoggerService } from '~/application/logger/logger-app.service';
+
+import { MARKETPLACE_EXTENSION_NAME } from '../../constants/marketplace-agreement-ids';
+import type { IConfig, ICoopAcceptanceConfig } from '../../types';
+import { defaultConfig } from '../../types';
+
+export interface IMarketplaceCppStatus {
+  status: 'active' | 'not_accepted';
+  document_registry_id?: number;
+  accepted_at?: string;
+  accepted_by_board_decision_id?: string;
+}
+
+export interface IAcceptCppInput {
+  document_registry_id: number;
+  accepted_by_board_decision_id: string;
+  /**
+   * ISO-8601 timestamp решения. Опционально — если не передан, берётся
+   * текущее время сервера (чистая функция от input + clock).
+   */
+  accepted_at?: string;
+}
+
+/**
+ * Story 1.9: L1-онбординг marketplace.
+ *
+ * Хранит флаг `coopAcceptance.accepted` в `extensions.config` (JSONB на
+ * `marketplace`-плагине). MVP-stub: председатель сам отмечает принятие
+ * положения Советом, передавая `accepted_by_board_decision_id`. В Эпике 8
+ * (FR40 «повестка совета») интеграция станет реальной — Mutation будет
+ * валидировать существование решения и его статус CONFIRMED.
+ *
+ * Resolver вызывает `accept` под `MarketplaceRoleGuard` с
+ * `@RequireMarketplaceAccess('Extension', 'configure')` — это admin-only.
+ *
+ * Side-effect: после `accept` Story 1.10 регистрирует marketplace-оферту в
+ * `coop_registration_offers_registry` (отдельный сервис, может слушать
+ * событие или дёргается ручкой из admin UI).
+ */
+@Injectable()
+export class MarketplaceCoopAcceptanceService {
+  constructor(
+    @Inject(EXTENSION_REPOSITORY)
+    private readonly extensionRepository: ExtensionDomainRepository<IConfig>,
+    private readonly logger: WinstonLoggerService
+  ) {
+    this.logger.setContext(MarketplaceCoopAcceptanceService.name);
+  }
+
+  async getStatus(): Promise<IMarketplaceCppStatus> {
+    const extension = await this.extensionRepository.findByName(MARKETPLACE_EXTENSION_NAME);
+    if (!extension) {
+      throw new NotFoundException(
+        `Расширение '${MARKETPLACE_EXTENSION_NAME}' не установлено — выполните Story 1.1 (install)`
+      );
+    }
+
+    const acceptance: ICoopAcceptanceConfig =
+      extension.config?.coopAcceptance ?? defaultConfig.coopAcceptance;
+
+    if (!acceptance.accepted) {
+      return { status: 'not_accepted' };
+    }
+
+    return {
+      status: 'active',
+      document_registry_id: acceptance.document_registry_id || undefined,
+      accepted_at: acceptance.accepted_at || undefined,
+      accepted_by_board_decision_id: acceptance.accepted_by_board_decision_id || undefined,
+    };
+  }
+
+  async accept(input: IAcceptCppInput): Promise<IMarketplaceCppStatus> {
+    const extension = await this.extensionRepository.findByName(MARKETPLACE_EXTENSION_NAME);
+    if (!extension) {
+      throw new NotFoundException(
+        `Расширение '${MARKETPLACE_EXTENSION_NAME}' не установлено — выполните Story 1.1 (install)`
+      );
+    }
+
+    const accepted_at = input.accepted_at ?? new Date().toISOString();
+    const acceptance: ICoopAcceptanceConfig = {
+      accepted: true,
+      document_registry_id: input.document_registry_id,
+      accepted_at,
+      accepted_by_board_decision_id: input.accepted_by_board_decision_id,
+    };
+
+    const nextConfig: IConfig = {
+      ...defaultConfig,
+      ...(extension.config ?? {}),
+      coopAcceptance: acceptance,
+    };
+
+    await this.extensionRepository.update({ name: MARKETPLACE_EXTENSION_NAME, config: nextConfig });
+
+    this.logger.info(
+      `[MARKETPLACE.L1] Положение ЦПП принято: document_registry_id=${input.document_registry_id}, board_decision_id=${input.accepted_by_board_decision_id}, accepted_at=${accepted_at}`
+    );
+
+    return {
+      status: 'active',
+      document_registry_id: acceptance.document_registry_id,
+      accepted_at: acceptance.accepted_at,
+      accepted_by_board_decision_id: acceptance.accepted_by_board_decision_id,
+    };
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/decorators/current-marketplace-member.decorator.ts
+++ b/components/controller/src/extensions/marketplace/application/decorators/current-marketplace-member.decorator.ts
@@ -1,0 +1,29 @@
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
+
+/**
+ * Извлекает `IMarketplaceCurrentMember` из GraphQL-context, куда его положил
+ * `MarketplaceMembershipGuard` (Story 1.3). Если context пуст — guard либо не
+ * сработал, либо был обойдён `server-secret` без последующей подмены; в этом
+ * случае подняли UnauthorizedException, чтобы не получить runtime-crash
+ * при попытке прочитать `currentMember.core_roles`.
+ */
+export const CurrentMarketplaceMember = createParamDecorator(
+  (_data: unknown, context: ExecutionContext): IMarketplaceCurrentMember => {
+    const ctx = GqlExecutionContext.create(context);
+    const gqlContext = ctx.getContext();
+    const currentMember =
+      (gqlContext?.currentMember as IMarketplaceCurrentMember | undefined) ??
+      (gqlContext?.req?.currentMember as IMarketplaceCurrentMember | undefined);
+
+    if (!currentMember) {
+      throw new UnauthorizedException(
+        'MarketplaceMembershipGuard не отработал — currentMember отсутствует в context'
+      );
+    }
+
+    return currentMember;
+  }
+);

--- a/components/controller/src/extensions/marketplace/application/decorators/marketplace-access.decorator.ts
+++ b/components/controller/src/extensions/marketplace/application/decorators/marketplace-access.decorator.ts
@@ -1,0 +1,27 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Story 1.8: декоратор `@RequireMarketplaceAccess('Resource', 'action')`.
+ *
+ * Альтернатива `@RequireMarketplaceRole(...)` (Story 1.6) — выражает требование
+ * через ресурс+действие из централизованной access-matrix
+ * (`marketplace-access-matrix.ts`). Используйте этот декоратор для нового
+ * кода; `@RequireMarketplaceRole` остаётся для обратной совместимости и
+ * для ситуаций, когда action не привязан к конкретному resource (например,
+ * проверка членства в совете).
+ *
+ * `MarketplaceRoleGuard` читает оба декоратора и применяет любую совпавшую
+ * семантику. Можно ставить оба, тогда guard потребует выполнения обоих.
+ */
+export const MARKETPLACE_ACCESS_METADATA_KEY = 'marketplace_access';
+
+export interface IMarketplaceAccessRequirement {
+  resource: string;
+  action: string;
+}
+
+export const RequireMarketplaceAccess = (resource: string, action: string) =>
+  SetMetadata<string, IMarketplaceAccessRequirement>(MARKETPLACE_ACCESS_METADATA_KEY, {
+    resource,
+    action,
+  });

--- a/components/controller/src/extensions/marketplace/application/decorators/marketplace-role.decorator.ts
+++ b/components/controller/src/extensions/marketplace/application/decorators/marketplace-role.decorator.ts
@@ -1,0 +1,20 @@
+import { SetMetadata } from '@nestjs/common';
+
+import type { MarketplaceRole } from '../membership/marketplace-roles.mapper';
+
+/**
+ * Метаданные decorator-а `@RequireMarketplaceRole('admin', 'board')`.
+ *
+ * Story 1.6: список marketplace-ролей, любая из которых даёт доступ к
+ * методу (OR-семантика). `MarketplaceRoleGuard` читает массив через
+ * `Reflector` и проверяет пересечение с `currentMember.marketplace_roles`.
+ *
+ * Если декоратор отсутствует — Guard разрешает (по аналогии с core
+ * `RolesGuard`: «нет требования — нет ограничения»). Тогда защиту
+ * обеспечивает только `MarketplaceMembershipGuard` (членство), а сам
+ * resolver работает для всех ролей.
+ */
+export const MARKETPLACE_ROLES_METADATA_KEY = 'marketplace_roles';
+
+export const RequireMarketplaceRole = (...roles: MarketplaceRole[]) =>
+  SetMetadata(MARKETPLACE_ROLES_METADATA_KEY, roles);

--- a/components/controller/src/extensions/marketplace/application/dto/marketplace-cpp-status.dto.ts
+++ b/components/controller/src/extensions/marketplace/application/dto/marketplace-cpp-status.dto.ts
@@ -1,0 +1,43 @@
+import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('MarketplaceCppStatus')
+export class MarketplaceCppStatusDTO {
+  @Field(() => String, {
+    description: '`active` — Совет принял положение ЦПП; `not_accepted` — расширение не подключено',
+  })
+  public readonly status!: 'active' | 'not_accepted';
+
+  @Field(() => Int, { nullable: true })
+  public readonly document_registry_id?: number;
+
+  @Field(() => String, { nullable: true })
+  public readonly accepted_at?: string;
+
+  @Field(() => String, { nullable: true })
+  public readonly accepted_by_board_decision_id?: string;
+
+  constructor(init: {
+    status: 'active' | 'not_accepted';
+    document_registry_id?: number;
+    accepted_at?: string;
+    accepted_by_board_decision_id?: string;
+  }) {
+    this.status = init.status;
+    this.document_registry_id = init.document_registry_id;
+    this.accepted_at = init.accepted_at;
+    this.accepted_by_board_decision_id = init.accepted_by_board_decision_id;
+  }
+}
+
+@InputType('MarketplaceAcceptCppInput')
+export class MarketplaceAcceptCppInputDTO {
+  @Field(() => Int, {
+    description: 'registry_id рендеренного instance положения ЦПП (Story 1.7 даст id из cooptypes)',
+  })
+  public document_registry_id!: number;
+
+  @Field(() => String, {
+    description: 'id решения Совета (FR40, Эпик 8). В MVP — stub string председателя.',
+  })
+  public accepted_by_board_decision_id!: string;
+}

--- a/components/controller/src/extensions/marketplace/application/dto/marketplace-current-member.dto.ts
+++ b/components/controller/src/extensions/marketplace/application/dto/marketplace-current-member.dto.ts
@@ -1,0 +1,33 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Маркет-контекст текущего пайщика: устанавливается `MarketplaceMembershipGuard`
+ * в request/ctx после проверки членства в кооперативе (Story 1.3).
+ *
+ * `core_roles` — массив core-ролей платформы (`User` / `Member` / `Chairman`).
+ * `marketplace_roles` — массив marketplace-специфичных ролей (`buyer`/`supplier`/
+ * `recipient`/`treasurer`/`controller`), наполняется в Story 1.6. Сейчас пусто.
+ */
+@ObjectType('MarketplaceCurrentMember')
+export class MarketplaceCurrentMemberDTO {
+  @Field(() => String)
+  public readonly username!: string;
+
+  @Field(() => [String])
+  public readonly core_roles!: string[];
+
+  @Field(() => [String])
+  public readonly marketplace_roles!: string[];
+
+  constructor(init: { username: string; core_roles: string[]; marketplace_roles: string[] }) {
+    this.username = init.username;
+    this.core_roles = init.core_roles;
+    this.marketplace_roles = init.marketplace_roles;
+  }
+}
+
+export interface IMarketplaceCurrentMember {
+  username: string;
+  core_roles: string[];
+  marketplace_roles: string[];
+}

--- a/components/controller/src/extensions/marketplace/application/dto/marketplace-member-wallet.dto.ts
+++ b/components/controller/src/extensions/marketplace/application/dto/marketplace-member-wallet.dto.ts
@@ -1,0 +1,60 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Story 1.5: ссылка marketplace на кошелёк ЦК пайщика.
+ *
+ * Источник данных — core `WalletService.getProgramWallet` для program_id=1
+ * (`ProgramType.MAIN`). Сплит `w.wal.share` + `w.wal.member` ledger2-кошелька
+ * сворачивается в один `ProgramWalletDomainEntity` (см.
+ * `WalletInteractor.assembleProgramWallets`):
+ *
+ *   - `available`               — `w.wal.share.available`
+ *   - `blocked`                 — `w.wal.share.blocked`
+ *   - `membership_contribution` — `w.wal.member.value` (членский вклад)
+ *
+ * `account_name` = `username` пайщика (логин в Цифровом кооперативе);
+ * `contract` = 'wallet'  — фиксированный owner-контракт для main program.
+ *
+ * Этого набора достаточно фронту `WalletTimeline` (UX-DR8) — баланс + членский
+ * вклад. Локальная таблица `marketplace_member_wallet_link` из PRD не
+ * заводится: core `WalletService` уже отдаёт данные из синхронизированного
+ * `ledger2::userwallets` (PG-кеш). RPC к chain не выполняется.
+ */
+@ObjectType('MarketplaceMemberWallet')
+export class MarketplaceMemberWalletDTO {
+  @Field(() => String)
+  public readonly username!: string;
+
+  @Field(() => String)
+  public readonly coopname!: string;
+
+  @Field(() => String, { description: 'Owner-контракт main program (wallet)' })
+  public readonly contract!: string;
+
+  @Field(() => String, { description: 'Доступный остаток (w.wal.share.available)' })
+  public readonly available!: string;
+
+  @Field(() => String, { description: 'Заблокированный остаток (w.wal.share.blocked)' })
+  public readonly blocked!: string;
+
+  @Field(() => String, {
+    description: 'Накопленный членский вклад (w.wal.member.value)',
+  })
+  public readonly membership_contribution!: string;
+
+  constructor(init: {
+    username: string;
+    coopname: string;
+    contract: string;
+    available: string;
+    blocked: string;
+    membership_contribution: string;
+  }) {
+    this.username = init.username;
+    this.coopname = init.coopname;
+    this.contract = init.contract;
+    this.available = init.available;
+    this.blocked = init.blocked;
+    this.membership_contribution = init.membership_contribution;
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/dto/marketplace-onboarding-state.dto.ts
+++ b/components/controller/src/extensions/marketplace/application/dto/marketplace-onboarding-state.dto.ts
@@ -1,0 +1,61 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Источник, по которому marketplace-онбординг считается завершённым:
+ *
+ *  - `registration_flow` — пайщик подписал оферту marketplace на этапе вступления
+ *    в кооператив (L2 онбординг, реализуется в Story 1.11);
+ *  - `extension_gate`   — пайщик подписал оферту через L3 fallback gate
+ *    непосредственно на столе (этой Story);
+ *  - `not_configured`   — оферта marketplace в платформенном
+ *    AgreementRegistry пока не зарегистрирована (Story 1.7 не выполнена,
+ *    `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0`) — gate не нужен.
+ *  - `gate_required`    — оферта зарегистрирована, но подписи пайщика ещё нет.
+ *
+ * Story 1.4 не различает `registration_flow` vs `extension_gate` по
+ * данным `soviet::agreements3` — пометка появится в Story 1.11 (поле
+ * `source` в локальной таблице, в agreements3 такого нет). До тех пор
+ * подписанная оферта приходит как `agreement_signed` без подкатегории.
+ */
+export type MarketplaceOnboardingSource =
+  | 'agreement_signed'
+  | 'not_configured'
+  | 'gate_required';
+
+@ObjectType('MarketplaceOnboardingState')
+export class MarketplaceOnboardingStateDTO {
+  @Field(() => Boolean, {
+    description:
+      'true — фронт должен показать gate-диалог OnboardingCPPGate; false — пайщик может попасть на стол сразу',
+  })
+  public readonly requires_gate!: boolean;
+
+  @Field(() => String)
+  public readonly source!: MarketplaceOnboardingSource;
+
+  @Field(() => Int, {
+    description:
+      'registry_id шаблона оферты ЦПП marketplace в платформенной document factory (Story 1.7). 0 — placeholder, оферта ещё не зарегистрирована.',
+  })
+  public readonly template_registry_id!: number;
+
+  @Field(() => String, { nullable: true })
+  public readonly completed_at?: string;
+
+  @Field(() => Int, { nullable: true })
+  public readonly agreement_id?: number;
+
+  constructor(init: {
+    requires_gate: boolean;
+    source: MarketplaceOnboardingSource;
+    template_registry_id: number;
+    completed_at?: string;
+    agreement_id?: number;
+  }) {
+    this.requires_gate = init.requires_gate;
+    this.source = init.source;
+    this.template_registry_id = init.template_registry_id;
+    this.completed_at = init.completed_at;
+    this.agreement_id = init.agreement_id;
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/guards/README.md
+++ b/components/controller/src/extensions/marketplace/application/guards/README.md
@@ -68,13 +68,58 @@ async marketplaceAdminAction(@CurrentMarketplaceMember() member: IMarketplaceCur
 | `[User, Member, Chairman]`        | —                     | `[orderer, board_readonly, admin, board]`      |
 | `[]` (admin платформы)            | любые                 | `[]` (guard membership уже отбросит 403)       |
 
+## Централизованная access-matrix (Story 1.8)
+
+`extensions/marketplace/application/access/marketplace-access-matrix.ts` —
+единое место, где описано «какая marketplace-роль может что делать с
+каким resource». Структура CASL-совместимая
+(`Record<role, Record<resource, action[]>>`).
+
+```ts
+// resolver:
+@UseGuards(GqlJwtAuthGuard, MarketplaceMembershipGuard, MarketplaceRoleGuard)
+@RequireMarketplaceAccess('Order', 'create')
+@Mutation(() => OrderDTO)
+async marketplaceCreateOrder(...) { ... }
+```
+
+`MarketplaceRoleGuard` читает обе семантики:
+- `@RequireMarketplaceRole('admin')` (Story 1.6) — OR по ролям.
+- `@RequireMarketplaceAccess('Order', 'create')` (Story 1.8) — через `canAccess`.
+
+Если оба декоратора заданы — guard требует выполнения обоих (логическое И).
+
+### Нотация actions
+
+| Action          | Семантика                                              |
+|-----------------|--------------------------------------------------------|
+| `create`        | Создание новой записи resource                         |
+| `read`          | Чтение любого экземпляра resource                      |
+| `read:own`      | Чтение только своих (`owner == username`)              |
+| `read:all`      | Чтение всех (без фильтра по ownership)                 |
+| `read:to-self`  | Чтение объектов, адресованных пайщику (recipient)      |
+| `read:own-KU`   | Чтение в рамках своего КУ (Эпик 2)                     |
+| `update:own`    | Изменение только своих                                 |
+| `delete:own`    | Удаление только своих                                  |
+| `cancel:own`    | Отмена своих                                           |
+| `moderate`      | Модерация (admin)                                      |
+| `manage`        | Полные права (admin)                                   |
+| `sign:first`    | Первая подпись в multisig                              |
+| `sign`          | Подпись (board)                                        |
+| `decide`        | Голосование по решению (board)                         |
+| `configure`    | Настройка расширения (admin/совет)                     |
+
+**Важно**: ownership-проверка (`:own`/`:own-KU`/`:to-self`) — задача
+resolver-а *после* прохождения guard. Guard отвечает за capability
+(«эта роль вообще может»), не за data-uniqueness.
+
 ## Phase 2 migration (CASL)
 
 Структура Guard остаётся, меняется только источник policy:
-`marketplace-roles.mapper.ts` транслируется в платформенный CASL
-`defineAbility`, Guard читает CASL-abilities (`ability.can(action, subject)`)
-вместо `Array.includes`. Декораторы остаются совместимыми.
-Behavior Guard — **тот же**.
+`marketplace-access-matrix.ts` транслируется в платформенный CASL
+`defineAbility`, `canAccess` подменяется на `ability.can(action, subject)`.
+Декораторы остаются совместимыми. Behavior Guard — **тот же**.
 
-Цель этой изоляции: бизнес-код resolver-ов (`@RequireMarketplaceRole('admin')`)
-не меняется при переходе на CASL.
+Цель этой изоляции: бизнес-код resolver-ов
+(`@RequireMarketplaceAccess('Order', 'create')`) не меняется при переходе
+на CASL.

--- a/components/controller/src/extensions/marketplace/application/guards/README.md
+++ b/components/controller/src/extensions/marketplace/application/guards/README.md
@@ -1,0 +1,80 @@
+# Guards расширения marketplace (Стол заказов)
+
+Локальная реализация security layer marketplace, MVP. Все guards живут
+изолированно в `extensions/marketplace/application/guards/` — core не знает
+про marketplace-роли.
+
+## `MarketplaceMembershipGuard` (Story 1.3)
+
+1. Требует валидный JWT (через `GqlJwtAuthGuard` выше по цепочке).
+2. Проверяет статус пайщика (`users.status === 'active'`, поднимается
+   `ParticipantStatusSyncService` по событию `action::soviet::addpartcpnt`).
+3. Формирует `IMarketplaceCurrentMember`:
+   - `username` — из JWT;
+   - `core_roles[]` — из `user.role` через `mapUserRoleToCoreRoles`;
+   - `marketplace_roles[]` — из `core_roles` через `mapCoreRolesToMarketplaceRoles`
+     (Story 1.6).
+4. Кладёт `currentMember` в `request.currentMember` + `ctx.currentMember` для
+   `@CurrentMarketplaceMember()`.
+5. `server-secret` пропускает guard (inter-service).
+
+## `MarketplaceRoleGuard` (Story 1.6)
+
+Ставится **после** `MarketplaceMembershipGuard`. Читает декоратор
+`@RequireMarketplaceRole('admin', 'board')` через `Reflector` и проверяет
+пересечение (`Array.find(includes)`) с `currentMember.marketplace_roles`.
+
+При запрете:
+- бросает `ForbiddenException` с детальным сообщением
+  `Forbidden: marketplace role 'admin' required, member has [orderer]`;
+- пишет structured log `forbidden-attempt` (`member`, `action`,
+  `requested_role`, `actual_marketplace_roles`, `actual_core_roles`).
+
+Если декоратор отсутствует — guard разрешает (по аналогии с core
+`RolesGuard`): «нет требования — нет ограничения».
+
+`server-secret` пропускает guard.
+
+## Pattern использования
+
+```typescript
+@UseGuards(GqlJwtAuthGuard, MarketplaceMembershipGuard, MarketplaceRoleGuard)
+@RequireMarketplaceRole('admin')
+@Mutation(() => SomeDTO)
+async marketplaceAdminAction(@CurrentMarketplaceMember() member: IMarketplaceCurrentMember) {
+  // member.core_roles, member.marketplace_roles доступны
+}
+```
+
+## Маппинг ролей
+
+`core-roles.mapper.ts`:
+
+| `user.role` (JWT)  | `core_roles`                       |
+|-------------------|-------------------------------------|
+| `user`            | `[User]`                            |
+| `member`          | `[User, Member]`                    |
+| `chairman`        | `[User, Member, Chairman]`          |
+| `admin`/unknown   | `[]`                                |
+
+`marketplace-roles.mapper.ts` (аддитивно):
+
+| `core_roles`                       | `+ context`            | `marketplace_roles`                            |
+|-----------------------------------|-----------------------|------------------------------------------------|
+| `[User]`                          | —                     | `[orderer]`                                    |
+| `[User]`                          | `isOfferer: true`     | `[orderer, offerer]` (Эпик 3, whitelist)       |
+| `[User]`                          | `isKuChairman: true`  | `[orderer, operator]` (Эпик 2, КУ)             |
+| `[User, Member]`                  | —                     | `[orderer, board_readonly]`                    |
+| `[User, Member, Chairman]`        | —                     | `[orderer, board_readonly, admin, board]`      |
+| `[]` (admin платформы)            | любые                 | `[]` (guard membership уже отбросит 403)       |
+
+## Phase 2 migration (CASL)
+
+Структура Guard остаётся, меняется только источник policy:
+`marketplace-roles.mapper.ts` транслируется в платформенный CASL
+`defineAbility`, Guard читает CASL-abilities (`ability.can(action, subject)`)
+вместо `Array.includes`. Декораторы остаются совместимыми.
+Behavior Guard — **тот же**.
+
+Цель этой изоляции: бизнес-код resolver-ов (`@RequireMarketplaceRole('admin')`)
+не меняется при переходе на CASL.

--- a/components/controller/src/extensions/marketplace/application/guards/marketplace-membership.guard.ts
+++ b/components/controller/src/extensions/marketplace/application/guards/marketplace-membership.guard.ts
@@ -6,6 +6,7 @@ import { MonoAccountStatusDomainInterface } from '~/domain/account/interfaces/mo
 
 import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
 import { mapUserRoleToCoreRoles } from '../membership/core-roles.mapper';
+import { mapCoreRolesToMarketplaceRoles } from '../membership/marketplace-roles.mapper';
 
 /**
  * Guard расширения marketplace (Стол заказов, Story 1.3).
@@ -44,10 +45,15 @@ export class MarketplaceMembershipGuard implements CanActivate {
       throw new ForbiddenException('Доступ только для пайщиков кооператива');
     }
 
+    const coreRoles = mapUserRoleToCoreRoles(user.role);
+    // Story 1.6: context-флаги (isOfferer/isKuChairman) пока всегда false —
+    // источники whitelist и КУ-председательства реализуются в Эпиках 2/3.
+    const marketplaceRoles = mapCoreRolesToMarketplaceRoles(coreRoles, {});
+
     const currentMember: IMarketplaceCurrentMember = {
       username: user.username,
-      core_roles: mapUserRoleToCoreRoles(user.role),
-      marketplace_roles: [],
+      core_roles: coreRoles,
+      marketplace_roles: marketplaceRoles,
     };
 
     request.currentMember = currentMember;

--- a/components/controller/src/extensions/marketplace/application/guards/marketplace-membership.guard.ts
+++ b/components/controller/src/extensions/marketplace/application/guards/marketplace-membership.guard.ts
@@ -1,0 +1,58 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+import config from '~/config/config';
+import { MonoAccountStatusDomainInterface } from '~/domain/account/interfaces/mono-account-domain.interface';
+
+import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
+import { mapUserRoleToCoreRoles } from '../membership/core-roles.mapper';
+
+/**
+ * Guard расширения marketplace (Стол заказов, Story 1.3).
+ *
+ * 1. Требует валидный JWT — без `request.user` → UnauthorizedException (HTTP 401,
+ *    клиент уходит на login).
+ * 2. Требует статус пайщика `active` (см. `ParticipantStatusSyncService`, который
+ *    повышает `users.status` после `soviet::addpartcpnt`) — иначе ForbiddenException
+ *    (HTTP 403, «Доступ только для пайщиков кооператива»).
+ * 3. Формирует `IMarketplaceCurrentMember` (`username`, `core_roles[]`,
+ *    `marketplace_roles[]` — пока []) и кладёт его в `request.currentMember`
+ *    и в GraphQL `ctx.currentMember` для последующих resolver-ов через
+ *    `@CurrentMarketplaceMember()`.
+ *
+ * Inter-service `server-secret` пропускает guard (как и core guards) — фоновые
+ * вызовы между controller'ом и core-сервисами не требуют членства.
+ */
+@Injectable()
+export class MarketplaceMembershipGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const ctx = GqlExecutionContext.create(context);
+    const gqlContext = ctx.getContext();
+    const request = gqlContext.req;
+
+    if (request?.headers?.['server-secret'] === config.server_secret) {
+      return true;
+    }
+
+    const user = request?.user as { username?: string; role?: string; status?: string } | undefined;
+
+    if (!user?.username) {
+      throw new UnauthorizedException('Требуется авторизованный пользователь');
+    }
+
+    if (user.status !== MonoAccountStatusDomainInterface.Active) {
+      throw new ForbiddenException('Доступ только для пайщиков кооператива');
+    }
+
+    const currentMember: IMarketplaceCurrentMember = {
+      username: user.username,
+      core_roles: mapUserRoleToCoreRoles(user.role),
+      marketplace_roles: [],
+    };
+
+    request.currentMember = currentMember;
+    gqlContext.currentMember = currentMember;
+
+    return true;
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/guards/marketplace-role.guard.ts
+++ b/components/controller/src/extensions/marketplace/application/guards/marketplace-role.guard.ts
@@ -1,0 +1,82 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+import config from '~/config/config';
+import { WinstonLoggerService } from '~/application/logger/logger-app.service';
+
+import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
+import { MARKETPLACE_ROLES_METADATA_KEY } from '../decorators/marketplace-role.decorator';
+import type { MarketplaceRole } from '../membership/marketplace-roles.mapper';
+
+/**
+ * Story 1.6: Guard проверки marketplace-роли.
+ *
+ * Ставится ПОСЛЕ `MarketplaceMembershipGuard` (тот формирует `currentMember`).
+ * Читает `@RequireMarketplaceRole(...)` метаданные → проверяет
+ * `Array.includes` хотя бы одной требуемой роли в `currentMember.marketplace_roles`.
+ *
+ * Решение принимается локально (MVP). В Phase 2 источник policy сменится с
+ * `marketplace-roles.mapper.ts` на платформенный CASL `defineAbility` —
+ * Guard и декоратор останутся, изменится только маппер.
+ *
+ * При запрете пишет structured log `forbidden-attempt` с member_id,
+ * action, requested_role, actual_marketplace_roles, actual_core_roles.
+ */
+@Injectable()
+export class MarketplaceRoleGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly logger: WinstonLoggerService
+  ) {
+    this.logger.setContext(MarketplaceRoleGuard.name);
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<MarketplaceRole[] | undefined>(
+      MARKETPLACE_ROLES_METADATA_KEY,
+      [context.getHandler(), context.getClass()]
+    );
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const ctx = GqlExecutionContext.create(context);
+    const gqlContext = ctx.getContext();
+    const request = gqlContext.req;
+
+    if (request?.headers?.['server-secret'] === config.server_secret) {
+      return true;
+    }
+
+    const currentMember =
+      (gqlContext?.currentMember as IMarketplaceCurrentMember | undefined) ??
+      (request?.currentMember as IMarketplaceCurrentMember | undefined);
+
+    if (!currentMember) {
+      // MarketplaceMembershipGuard должен был отработать раньше; если не сработал —
+      // отказываем (защита от рассогласования настройки UseGuards).
+      throw new ForbiddenException(
+        'Marketplace-контекст не инициализирован — поставьте MarketplaceMembershipGuard в @UseGuards раньше MarketplaceRoleGuard'
+      );
+    }
+
+    const matched = requiredRoles.find((role) => currentMember.marketplace_roles.includes(role));
+    if (matched) {
+      return true;
+    }
+
+    const requestedLabel = requiredRoles.join(', ');
+    const handlerName = context.getHandler()?.name ?? 'unknown_handler';
+    const className = context.getClass()?.name ?? 'unknown_class';
+
+    this.logger.warn(
+      `forbidden-attempt: member=${currentMember.username} action=${className}.${handlerName} requested_role=[${requestedLabel}] actual_marketplace_roles=[${currentMember.marketplace_roles.join(', ')}] actual_core_roles=[${currentMember.core_roles.join(', ')}]`
+    );
+
+    throw new ForbiddenException(
+      `Forbidden: marketplace role '${requestedLabel}' required, member has [${currentMember.marketplace_roles.join(', ')}]`
+    );
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/guards/marketplace-role.guard.ts
+++ b/components/controller/src/extensions/marketplace/application/guards/marketplace-role.guard.ts
@@ -5,23 +5,30 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import config from '~/config/config';
 import { WinstonLoggerService } from '~/application/logger/logger-app.service';
 
+import { canAccess } from '../access/marketplace-access-matrix';
+import {
+  MARKETPLACE_ACCESS_METADATA_KEY,
+  type IMarketplaceAccessRequirement,
+} from '../decorators/marketplace-access.decorator';
 import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
 import { MARKETPLACE_ROLES_METADATA_KEY } from '../decorators/marketplace-role.decorator';
 import type { MarketplaceRole } from '../membership/marketplace-roles.mapper';
 
 /**
- * Story 1.6: Guard проверки marketplace-роли.
+ * Guard проверки авторизации marketplace.
  *
- * Ставится ПОСЛЕ `MarketplaceMembershipGuard` (тот формирует `currentMember`).
- * Читает `@RequireMarketplaceRole(...)` метаданные → проверяет
- * `Array.includes` хотя бы одной требуемой роли в `currentMember.marketplace_roles`.
+ * Поддерживает обе семантики (Story 1.6 + Story 1.8):
+ *   - `@RequireMarketplaceRole('admin', 'board')` — OR по ролям;
+ *   - `@RequireMarketplaceAccess('Order', 'create')` — проверка через
+ *     централизованную access-matrix (`marketplace-access-matrix.ts`).
  *
- * Решение принимается локально (MVP). В Phase 2 источник policy сменится с
- * `marketplace-roles.mapper.ts` на платформенный CASL `defineAbility` —
- * Guard и декоратор останутся, изменится только маппер.
+ * Если декораторы заданы оба — guard требует выполнения обоих
+ * (логическое И). Если ни одного — guard разрешает (по аналогии с core
+ * RolesGuard: «нет требования — нет ограничения», membership проверяется
+ * отдельно `MarketplaceMembershipGuard`).
  *
- * При запрете пишет structured log `forbidden-attempt` с member_id,
- * action, requested_role, actual_marketplace_roles, actual_core_roles.
+ * Phase 2 миграция: `canAccess` подменяется на `ability.can(action, subject)`
+ * — interface guard'а не меняется.
  */
 @Injectable()
 export class MarketplaceRoleGuard implements CanActivate {
@@ -37,8 +44,12 @@ export class MarketplaceRoleGuard implements CanActivate {
       MARKETPLACE_ROLES_METADATA_KEY,
       [context.getHandler(), context.getClass()]
     );
+    const requiredAccess = this.reflector.getAllAndOverride<
+      IMarketplaceAccessRequirement | undefined
+    >(MARKETPLACE_ACCESS_METADATA_KEY, [context.getHandler(), context.getClass()]);
 
-    if (!requiredRoles || requiredRoles.length === 0) {
+    const noRoles = !requiredRoles || requiredRoles.length === 0;
+    if (noRoles && !requiredAccess) {
       return true;
     }
 
@@ -55,28 +66,39 @@ export class MarketplaceRoleGuard implements CanActivate {
       (request?.currentMember as IMarketplaceCurrentMember | undefined);
 
     if (!currentMember) {
-      // MarketplaceMembershipGuard должен был отработать раньше; если не сработал —
-      // отказываем (защита от рассогласования настройки UseGuards).
       throw new ForbiddenException(
         'Marketplace-контекст не инициализирован — поставьте MarketplaceMembershipGuard в @UseGuards раньше MarketplaceRoleGuard'
       );
     }
 
-    const matched = requiredRoles.find((role) => currentMember.marketplace_roles.includes(role));
-    if (matched) {
-      return true;
-    }
-
-    const requestedLabel = requiredRoles.join(', ');
     const handlerName = context.getHandler()?.name ?? 'unknown_handler';
     const className = context.getClass()?.name ?? 'unknown_class';
+    const memberRoles = currentMember.marketplace_roles as MarketplaceRole[];
 
-    this.logger.warn(
-      `forbidden-attempt: member=${currentMember.username} action=${className}.${handlerName} requested_role=[${requestedLabel}] actual_marketplace_roles=[${currentMember.marketplace_roles.join(', ')}] actual_core_roles=[${currentMember.core_roles.join(', ')}]`
-    );
+    if (!noRoles && requiredRoles) {
+      const matched = requiredRoles.find((role) => memberRoles.includes(role));
+      if (!matched) {
+        this.logger.warn(
+          `forbidden-attempt: member=${currentMember.username} action=${className}.${handlerName} requested_role=[${requiredRoles.join(', ')}] actual_marketplace_roles=[${memberRoles.join(', ')}] actual_core_roles=[${currentMember.core_roles.join(', ')}]`
+        );
+        throw new ForbiddenException(
+          `Forbidden: marketplace role '${requiredRoles.join(', ')}' required, member has [${memberRoles.join(', ')}]`
+        );
+      }
+    }
 
-    throw new ForbiddenException(
-      `Forbidden: marketplace role '${requestedLabel}' required, member has [${currentMember.marketplace_roles.join(', ')}]`
-    );
+    if (requiredAccess) {
+      const ok = canAccess(memberRoles, requiredAccess.resource, requiredAccess.action);
+      if (!ok) {
+        this.logger.warn(
+          `forbidden-attempt: member=${currentMember.username} action=${className}.${handlerName} requested_access=${requiredAccess.resource}:${requiredAccess.action} actual_marketplace_roles=[${memberRoles.join(', ')}] actual_core_roles=[${currentMember.core_roles.join(', ')}]`
+        );
+        throw new ForbiddenException(
+          `Forbidden: marketplace access '${requiredAccess.resource}:${requiredAccess.action}' required, member has roles [${memberRoles.join(', ')}]`
+        );
+      }
+    }
+
+    return true;
   }
 }

--- a/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
+++ b/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { MarketplaceExtensionDomainModule } from '../domain/marketplace-domain.module';
+import { WalletModule } from '~/application/wallet/wallet.module';
 import { CategoryTreeResolver } from './resolvers/category-tree.resolver';
 import { AttributeResolver } from './resolvers/attribute.resolver';
 import { AvailableCategoryAdminResolver } from './resolvers/available-category-admin.resolver';
 import { RequestResolver } from './resolvers/request.resolver';
 import { MarketplaceMembershipResolver } from './resolvers/marketplace-membership.resolver';
 import { MarketplaceOnboardingResolver } from './resolvers/marketplace-onboarding.resolver';
+import { MarketplaceMemberWalletResolver } from './resolvers/marketplace-member-wallet.resolver';
 import { MarketplaceMembershipGuard } from './guards/marketplace-membership.guard';
 import { MarketplaceOnboardingService } from './onboarding/marketplace-onboarding.service';
 import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-tree.service';
@@ -15,7 +17,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
  * Содержит GraphQL резолверы и сервисы приложения
  */
 @Module({
-  imports: [MarketplaceExtensionDomainModule],
+  imports: [MarketplaceExtensionDomainModule, WalletModule],
   providers: [
     // GraphQL резолверы
     CategoryTreeResolver,
@@ -24,6 +26,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     RequestResolver,
     MarketplaceMembershipResolver,
     MarketplaceOnboardingResolver,
+    MarketplaceMemberWalletResolver,
 
     // Guards (Story 1.3)
     MarketplaceMembershipGuard,
@@ -49,6 +52,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     RequestResolver,
     MarketplaceMembershipResolver,
     MarketplaceOnboardingResolver,
+    MarketplaceMemberWalletResolver,
   ],
 })
 export class MarketplaceExtensionApplicationModule {}

--- a/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
+++ b/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
@@ -8,9 +8,11 @@ import { RequestResolver } from './resolvers/request.resolver';
 import { MarketplaceMembershipResolver } from './resolvers/marketplace-membership.resolver';
 import { MarketplaceOnboardingResolver } from './resolvers/marketplace-onboarding.resolver';
 import { MarketplaceMemberWalletResolver } from './resolvers/marketplace-member-wallet.resolver';
+import { MarketplaceCoopAcceptanceResolver } from './resolvers/marketplace-coop-acceptance.resolver';
 import { MarketplaceMembershipGuard } from './guards/marketplace-membership.guard';
 import { MarketplaceRoleGuard } from './guards/marketplace-role.guard';
 import { MarketplaceOnboardingService } from './onboarding/marketplace-onboarding.service';
+import { MarketplaceCoopAcceptanceService } from './coop-acceptance/marketplace-coop-acceptance.service';
 import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-tree.service';
 
 /**
@@ -28,6 +30,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     MarketplaceMembershipResolver,
     MarketplaceOnboardingResolver,
     MarketplaceMemberWalletResolver,
+    MarketplaceCoopAcceptanceResolver,
 
     // Guards (Story 1.3 / Story 1.6)
     MarketplaceMembershipGuard,
@@ -40,6 +43,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     },
     CategoryTreeService,
     MarketplaceOnboardingService,
+    MarketplaceCoopAcceptanceService,
   ],
   exports: [
     // Экспортируем сервисы для использования в других модулях
@@ -47,6 +51,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     MarketplaceMembershipGuard,
     MarketplaceRoleGuard,
     MarketplaceOnboardingService,
+    MarketplaceCoopAcceptanceService,
 
     // Экспортируем резолверы для регистрации в GraphQL
     CategoryTreeResolver,
@@ -56,6 +61,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     MarketplaceMembershipResolver,
     MarketplaceOnboardingResolver,
     MarketplaceMemberWalletResolver,
+    MarketplaceCoopAcceptanceResolver,
   ],
 })
 export class MarketplaceExtensionApplicationModule {}

--- a/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
+++ b/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
@@ -5,7 +5,9 @@ import { AttributeResolver } from './resolvers/attribute.resolver';
 import { AvailableCategoryAdminResolver } from './resolvers/available-category-admin.resolver';
 import { RequestResolver } from './resolvers/request.resolver';
 import { MarketplaceMembershipResolver } from './resolvers/marketplace-membership.resolver';
+import { MarketplaceOnboardingResolver } from './resolvers/marketplace-onboarding.resolver';
 import { MarketplaceMembershipGuard } from './guards/marketplace-membership.guard';
+import { MarketplaceOnboardingService } from './onboarding/marketplace-onboarding.service';
 import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-tree.service';
 
 /**
@@ -21,6 +23,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     AvailableCategoryAdminResolver,
     RequestResolver,
     MarketplaceMembershipResolver,
+    MarketplaceOnboardingResolver,
 
     // Guards (Story 1.3)
     MarketplaceMembershipGuard,
@@ -31,11 +34,13 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
       useClass: CategoryTreeService,
     },
     CategoryTreeService,
+    MarketplaceOnboardingService,
   ],
   exports: [
     // Экспортируем сервисы для использования в других модулях
     CATEGORY_TREE_SERVICE,
     MarketplaceMembershipGuard,
+    MarketplaceOnboardingService,
 
     // Экспортируем резолверы для регистрации в GraphQL
     CategoryTreeResolver,
@@ -43,6 +48,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     AvailableCategoryAdminResolver,
     RequestResolver,
     MarketplaceMembershipResolver,
+    MarketplaceOnboardingResolver,
   ],
 })
 export class MarketplaceExtensionApplicationModule {}

--- a/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
+++ b/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
@@ -4,6 +4,8 @@ import { CategoryTreeResolver } from './resolvers/category-tree.resolver';
 import { AttributeResolver } from './resolvers/attribute.resolver';
 import { AvailableCategoryAdminResolver } from './resolvers/available-category-admin.resolver';
 import { RequestResolver } from './resolvers/request.resolver';
+import { MarketplaceMembershipResolver } from './resolvers/marketplace-membership.resolver';
+import { MarketplaceMembershipGuard } from './guards/marketplace-membership.guard';
 import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-tree.service';
 
 /**
@@ -18,6 +20,10 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     AttributeResolver,
     AvailableCategoryAdminResolver,
     RequestResolver,
+    MarketplaceMembershipResolver,
+
+    // Guards (Story 1.3)
+    MarketplaceMembershipGuard,
 
     // Сервисы приложения
     {
@@ -29,12 +35,14 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
   exports: [
     // Экспортируем сервисы для использования в других модулях
     CATEGORY_TREE_SERVICE,
+    MarketplaceMembershipGuard,
 
     // Экспортируем резолверы для регистрации в GraphQL
     CategoryTreeResolver,
     AttributeResolver,
     AvailableCategoryAdminResolver,
     RequestResolver,
+    MarketplaceMembershipResolver,
   ],
 })
 export class MarketplaceExtensionApplicationModule {}

--- a/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
+++ b/components/controller/src/extensions/marketplace/application/marketplace-application.module.ts
@@ -9,6 +9,7 @@ import { MarketplaceMembershipResolver } from './resolvers/marketplace-membershi
 import { MarketplaceOnboardingResolver } from './resolvers/marketplace-onboarding.resolver';
 import { MarketplaceMemberWalletResolver } from './resolvers/marketplace-member-wallet.resolver';
 import { MarketplaceMembershipGuard } from './guards/marketplace-membership.guard';
+import { MarketplaceRoleGuard } from './guards/marketplace-role.guard';
 import { MarketplaceOnboardingService } from './onboarding/marketplace-onboarding.service';
 import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-tree.service';
 
@@ -28,8 +29,9 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     MarketplaceOnboardingResolver,
     MarketplaceMemberWalletResolver,
 
-    // Guards (Story 1.3)
+    // Guards (Story 1.3 / Story 1.6)
     MarketplaceMembershipGuard,
+    MarketplaceRoleGuard,
 
     // Сервисы приложения
     {
@@ -43,6 +45,7 @@ import { CategoryTreeService, CATEGORY_TREE_SERVICE } from './services/category-
     // Экспортируем сервисы для использования в других модулях
     CATEGORY_TREE_SERVICE,
     MarketplaceMembershipGuard,
+    MarketplaceRoleGuard,
     MarketplaceOnboardingService,
 
     // Экспортируем резолверы для регистрации в GraphQL

--- a/components/controller/src/extensions/marketplace/application/membership/core-roles.mapper.ts
+++ b/components/controller/src/extensions/marketplace/application/membership/core-roles.mapper.ts
@@ -1,0 +1,27 @@
+/**
+ * Маппер core-ролей пайщика из единственной `user.role` (строка из JWT
+ * payload, см. `JwtAuthStrategy.validate`) в массив core-ролей платформы.
+ *
+ * Иерархия (см. memory `reference_core_controller_roli`):
+ *   `user`      — обычный пайщик → ['User'].
+ *   `member`    — член совета (тоже пайщик) → ['User', 'Member'].
+ *   `chairman`  — председатель (входит в совет) → ['User', 'Member', 'Chairman'].
+ *   прочее (`admin`/неизвестное) — не кооперативная роль → [].
+ *
+ * Story 1.6 дополнит этим маппером `MarketplaceMembershipGuard`, а сам
+ * массив будет использоваться access-matrix (Story 1.8) для проверок
+ * прав, не дублируя core-логику.
+ */
+
+export type CoreRole = 'User' | 'Member' | 'Chairman';
+
+const ROLE_TO_CORE: Record<string, CoreRole[]> = {
+  user: ['User'],
+  member: ['User', 'Member'],
+  chairman: ['User', 'Member', 'Chairman'],
+};
+
+export function mapUserRoleToCoreRoles(userRole: string | undefined | null): CoreRole[] {
+  if (!userRole) return [];
+  return ROLE_TO_CORE[userRole] ?? [];
+}

--- a/components/controller/src/extensions/marketplace/application/membership/marketplace-roles.mapper.ts
+++ b/components/controller/src/extensions/marketplace/application/membership/marketplace-roles.mapper.ts
@@ -1,0 +1,69 @@
+import type { CoreRole } from './core-roles.mapper';
+
+/**
+ * Marketplace-роли — массивные (Array.includes), не enum.
+ *
+ * Phase 2 уйдёт в платформенный CASL (`defineAbility`) — поведение Guard
+ * не изменится, только источник policy сменится с access-matrix.ts на
+ * CASL-abilities. См. README рядом с guard.
+ */
+export type MarketplaceRole =
+  | 'orderer'        // Любой пайщик: оформляет заказ
+  | 'offerer'        // Поставщик из whitelist (Эпик 3): публикует предложения
+  | 'operator'       // Председатель КУ (Эпик 2): операции по своему КУ
+  | 'board_readonly' // Member: read-only к admin-данным
+  | 'board'          // Chairman: полные права в повестке совета
+  | 'admin';         // Chairman: full admin
+
+/**
+ * Контекст для расширенных marketplace-ролей.
+ *
+ * `isOfferer` (whitelist поставщиков) реализуется в Эпике 3 — пока всегда
+ * false. `isKuChairman` (председатель КУ) — в Эпике 2; до этого момента
+ * `operator` никому не выдаётся. Поля оставлены в сигнатуре, чтобы
+ * добавить источники без изменения mapper.
+ */
+export interface IMarketplaceRoleContext {
+  isOfferer?: boolean;
+  isKuChairman?: boolean;
+}
+
+/**
+ * Маппинг core_roles[] + context → marketplace_roles[].
+ *
+ * Аддитивный:
+ *   `User` (всегда у пайщика, см. core-roles.mapper)        → [orderer]
+ *   + opts.isOfferer                                        → +offerer
+ *   + opts.isKuChairman                                     → +operator
+ *   `Member` (в core)                                       → +board_readonly
+ *   `Chairman` (в core)                                     → +admin, +board
+ *
+ * Пайщик БЕЗ `User` в core_roles (admin-роль платформы или невалидное
+ * состояние) → marketplace_roles = []. Guard вышестоящего уровня
+ * (`MarketplaceMembershipGuard`) такого пайщика уже отбросит 403, но
+ * mapper остаётся пуристичным.
+ */
+export function mapCoreRolesToMarketplaceRoles(
+  coreRoles: CoreRole[],
+  context: IMarketplaceRoleContext = {}
+): MarketplaceRole[] {
+  if (!coreRoles.includes('User')) {
+    return [];
+  }
+
+  const roles: MarketplaceRole[] = ['orderer'];
+
+  if (context.isOfferer) roles.push('offerer');
+  if (context.isKuChairman) roles.push('operator');
+
+  if (coreRoles.includes('Member')) {
+    roles.push('board_readonly');
+  }
+
+  if (coreRoles.includes('Chairman')) {
+    roles.push('admin');
+    roles.push('board');
+  }
+
+  return roles;
+}

--- a/components/controller/src/extensions/marketplace/application/onboarding/marketplace-onboarding.service.ts
+++ b/components/controller/src/extensions/marketplace/application/onboarding/marketplace-onboarding.service.ts
@@ -1,0 +1,80 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { AGREEMENT_REPOSITORY, AgreementRepository } from '~/domain/agreement/repositories/agreement.repository';
+import { WinstonLoggerService } from '~/application/logger/logger-app.service';
+
+import {
+  MARKETPLACE_AGREEMENT_TYPE,
+  MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID,
+} from '../../constants/marketplace-agreement-ids';
+import type { MarketplaceOnboardingSource } from '../dto/marketplace-onboarding-state.dto';
+import { MarketplaceOnboardingStateDTO } from '../dto/marketplace-onboarding-state.dto';
+
+/**
+ * Story 1.4: L3 fallback gate marketplace.
+ *
+ * Контракт: расширение само не хранит «подписал/не подписал». Источник правды —
+ * `soviet::agreements3`, синхронизированная в `AgreementRepository` через
+ * `AgreementSyncService` (см. CLAUDE.md read-path: только PG-repository).
+ *
+ * Локальная таблица `marketplace_onboarding_state` из PRD не заводится:
+ * - `AgreementRepository.findByUsername` уже даёт быстрый доступ к подписям
+ *   (PG индекс по username);
+ * - различение source ('registration_flow' vs 'extension_gate') в текущей
+ *   `agreements3` отсутствует — оба пути пишут одинаковую запись с
+ *   `agreement_type = 'marketplace'`. Story 1.11 при добавлении L2 при
+ *   необходимости заведёт локальный source-маркер.
+ *
+ * TTL 60s из PRD AC тоже опускаем — `AgreementRepository` сам синхронизирован
+ * с blockchain, локальный staleness ничем не отличается от core data.
+ */
+@Injectable()
+export class MarketplaceOnboardingService {
+  constructor(
+    @Inject(AGREEMENT_REPOSITORY) private readonly agreementRepository: AgreementRepository,
+    private readonly logger: WinstonLoggerService
+  ) {
+    this.logger.setContext(MarketplaceOnboardingService.name);
+  }
+
+  async getOnboardingState(username: string): Promise<MarketplaceOnboardingStateDTO> {
+    const templateRegistryId = MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID;
+
+    if (templateRegistryId <= 0) {
+      // Story 1.7 не выполнена — нечего показывать в gate, фронт пропускает.
+      return new MarketplaceOnboardingStateDTO({
+        requires_gate: false,
+        source: 'not_configured',
+        template_registry_id: 0,
+      });
+    }
+
+    const agreements = await this.agreementRepository.findByUsername(username);
+    const signed = agreements.find(
+      (a) =>
+        a.type === MARKETPLACE_AGREEMENT_TYPE &&
+        (a.draft_id === undefined ||
+          a.draft_id === null ||
+          Number(a.draft_id) === templateRegistryId)
+    );
+
+    if (signed) {
+      const source: MarketplaceOnboardingSource = 'agreement_signed';
+      return new MarketplaceOnboardingStateDTO({
+        requires_gate: false,
+        source,
+        template_registry_id: templateRegistryId,
+        completed_at: signed.updated_at ? String(signed.updated_at) : undefined,
+        agreement_id: signed.id ?? undefined,
+      });
+    }
+
+    return new MarketplaceOnboardingStateDTO({
+      requires_gate: true,
+      source: 'gate_required',
+      template_registry_id: templateRegistryId,
+    });
+  }
+}
+
+export const MARKETPLACE_ONBOARDING_SERVICE = Symbol('MARKETPLACE_ONBOARDING_SERVICE');

--- a/components/controller/src/extensions/marketplace/application/registration/register-marketplace-in-agreement-registry.ts
+++ b/components/controller/src/extensions/marketplace/application/registration/register-marketplace-in-agreement-registry.ts
@@ -1,0 +1,50 @@
+import { AccountType } from '~/application/account/enum/account-type.enum';
+import type { AgreementRegistrationPort } from '~/domain/registration/ports/agreement-registration.port';
+import {
+  MARKETPLACE_AGREEMENT_TYPE,
+  MARKETPLACE_EXTENSION_NAME,
+  MARKETPLACE_OFFER_AGREEMENT_ID,
+  MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID,
+} from '../../constants/marketplace-agreement-ids';
+
+/**
+ * Регистрация оферты marketplace (Стол заказов) в платформенном AgreementRegistry.
+ *
+ * Чистая функция, не имеющая зависимостей от NestJS-контейнера — упрощает
+ * unit-тестирование (по образцу `registerCapitalInAgreementRegistry`).
+ *
+ * Логика Story 1.2:
+ *   • если `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID ≤ 0` (template ещё не
+ *     создан в document factory — Story 1.7 не выполнена) — port не вызывается,
+ *     SignUp не предлагает оферту marketplace; функция возвращает false;
+ *   • при реальном `registry_id > 0` — `registerAgreement` × 1 для оферты ЦПП
+ *     «Стол заказов» с типами аккаунтов `individual` + `entrepreneur`.
+ *
+ * Идемпотентность гарантируется самим `AgreementRegistryService` (повторный
+ * register с тем же id+extension_name перезаписывает запись, см. док-комментарий
+ * `AgreementRegistrationPort`).
+ *
+ * Programs для marketplace MVP не регистрируются: Стол заказов — это ЦПП без
+ * программы участия (в отличие от Благороста с GENERATION/CAPITALIZATION).
+ */
+export function registerMarketplaceInAgreementRegistry(
+  port: AgreementRegistrationPort
+): boolean {
+  if (MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID <= 0) {
+    return false;
+  }
+
+  port.registerAgreement({
+    id: MARKETPLACE_OFFER_AGREEMENT_ID,
+    registry_id: MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID,
+    agreement_type: MARKETPLACE_AGREEMENT_TYPE,
+    title: 'Оферта по целевой потребительской программе «Стол заказов»',
+    checkbox_text: 'Я прочитал и принимаю',
+    link_text: 'оферту по целевой потребительской программе «Стол заказов»',
+    applicable_account_types: [AccountType.individual, AccountType.entrepreneur],
+    order: 7,
+    extension_name: MARKETPLACE_EXTENSION_NAME,
+  });
+
+  return true;
+}

--- a/components/controller/src/extensions/marketplace/application/resolvers/marketplace-coop-acceptance.resolver.ts
+++ b/components/controller/src/extensions/marketplace/application/resolvers/marketplace-coop-acceptance.resolver.ts
@@ -1,0 +1,55 @@
+import { Injectable, UseGuards } from '@nestjs/common';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+
+import { GqlJwtAuthGuard } from '~/application/auth/guards/graphql-jwt-auth.guard';
+
+import { RequireMarketplaceAccess } from '../decorators/marketplace-access.decorator';
+import {
+  MarketplaceAcceptCppInputDTO,
+  MarketplaceCppStatusDTO,
+} from '../dto/marketplace-cpp-status.dto';
+import { MarketplaceMembershipGuard } from '../guards/marketplace-membership.guard';
+import { MarketplaceRoleGuard } from '../guards/marketplace-role.guard';
+import { MarketplaceCoopAcceptanceService } from '../coop-acceptance/marketplace-coop-acceptance.service';
+
+/**
+ * Story 1.9: L1-онбординг marketplace.
+ *
+ * `Query marketplaceCppStatus` — открыт всем активным пайщикам (нужен фронту,
+ * чтобы решить, показывать ли баннер «Не подключено» или открыть рабочее
+ * пространство); admin-action для самой mutation идёт через
+ * `@RequireMarketplaceAccess('Extension', 'configure')`.
+ */
+@Resolver()
+@Injectable()
+export class MarketplaceCoopAcceptanceResolver {
+  constructor(private readonly acceptanceService: MarketplaceCoopAcceptanceService) {}
+
+  @Query(() => MarketplaceCppStatusDTO, {
+    name: 'marketplaceCppStatus',
+    description:
+      'Статус принятия положения ЦПП «Стол заказов» Советом кооператива (L1). `active` если принято, `not_accepted` иначе.',
+  })
+  @UseGuards(GqlJwtAuthGuard, MarketplaceMembershipGuard)
+  async marketplaceCppStatus(): Promise<MarketplaceCppStatusDTO> {
+    const status = await this.acceptanceService.getStatus();
+    return new MarketplaceCppStatusDTO(status);
+  }
+
+  @Mutation(() => MarketplaceCppStatusDTO, {
+    name: 'marketplaceAcceptCpp',
+    description:
+      'Зафиксировать принятие положения ЦПП «Стол заказов» Советом — admin-action из admin-стола. MVP-stub: председатель самостоятельно передаёт `accepted_by_board_decision_id`; в Эпике 8 поле будет валидироваться против реальной повестки совета.',
+  })
+  @UseGuards(GqlJwtAuthGuard, MarketplaceMembershipGuard, MarketplaceRoleGuard)
+  @RequireMarketplaceAccess('Extension', 'configure')
+  async marketplaceAcceptCpp(
+    @Args('input') input: MarketplaceAcceptCppInputDTO
+  ): Promise<MarketplaceCppStatusDTO> {
+    const status = await this.acceptanceService.accept({
+      document_registry_id: input.document_registry_id,
+      accepted_by_board_decision_id: input.accepted_by_board_decision_id,
+    });
+    return new MarketplaceCppStatusDTO(status);
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/resolvers/marketplace-member-wallet.resolver.ts
+++ b/components/controller/src/extensions/marketplace/application/resolvers/marketplace-member-wallet.resolver.ts
@@ -1,0 +1,62 @@
+import { Injectable, NotFoundException, UseGuards } from '@nestjs/common';
+import { Query, Resolver } from '@nestjs/graphql';
+
+import config from '~/config/config';
+import { GqlJwtAuthGuard } from '~/application/auth/guards/graphql-jwt-auth.guard';
+import { WalletService } from '~/application/wallet/services/wallet.service';
+import { ProgramType } from '~/domain/wallet/enums/program-type.enum';
+
+import { CurrentMarketplaceMember } from '../decorators/current-marketplace-member.decorator';
+import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
+import { MarketplaceMemberWalletDTO } from '../dto/marketplace-member-wallet.dto';
+import { MarketplaceMembershipGuard } from '../guards/marketplace-membership.guard';
+
+/**
+ * Story 1.5: GraphQL endpoint marketplace для чтения кошелька пайщика ЦК.
+ *
+ * Делегирует чтение в core `WalletService.getProgramWallet` (program_id=1,
+ * ProgramType.MAIN); локальной таблицы `marketplace_member_wallet_link` нет —
+ * core PG-кеш `ledger2::userwallets` уже консистентен с blockchain.
+ *
+ * AC PRD говорит про REST `GET /api/wallet/member/<account>` — controller
+ * целиком GraphQL, делаем эквивалент `Query marketplaceMemberWallet`.
+ * Расхождение зафиксировано как техдолг PRD.
+ */
+@Resolver()
+@Injectable()
+export class MarketplaceMemberWalletResolver {
+  constructor(private readonly walletService: WalletService) {}
+
+  @Query(() => MarketplaceMemberWalletDTO, {
+    name: 'marketplaceMemberWallet',
+    description:
+      'Кошелёк пайщика (Цифровой кошелёк, program_id=1): available/blocked + membership_contribution',
+  })
+  @UseGuards(GqlJwtAuthGuard, MarketplaceMembershipGuard)
+  async marketplaceMemberWallet(
+    @CurrentMarketplaceMember() currentMember: IMarketplaceCurrentMember
+  ): Promise<MarketplaceMemberWalletDTO> {
+    const coopname = config.coopname;
+    const wallet = await this.walletService.getProgramWallet({
+      coopname,
+      username: currentMember.username,
+      program_type: ProgramType.MAIN,
+    });
+
+    if (!wallet) {
+      // PG-кеш ничего не отдал — пайщик ещё не открывал main wallet через
+      // ledger2; повторим запрос после доставки delta (CLAUDE.md запрещает
+      // RPC fallback в read-path).
+      throw new NotFoundException('Кошелёк пайщика ЦК не найден в локальном кеше');
+    }
+
+    return new MarketplaceMemberWalletDTO({
+      username: currentMember.username,
+      coopname,
+      contract: 'wallet',
+      available: wallet.available ?? '0',
+      blocked: wallet.blocked ?? '0',
+      membership_contribution: wallet.membership_contribution ?? '0',
+    });
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/resolvers/marketplace-membership.resolver.ts
+++ b/components/controller/src/extensions/marketplace/application/resolvers/marketplace-membership.resolver.ts
@@ -1,0 +1,32 @@
+import { Injectable, UseGuards } from '@nestjs/common';
+import { Query, Resolver } from '@nestjs/graphql';
+
+import { GqlJwtAuthGuard } from '~/application/auth/guards/graphql-jwt-auth.guard';
+
+import { CurrentMarketplaceMember } from '../decorators/current-marketplace-member.decorator';
+import { MarketplaceCurrentMemberDTO } from '../dto/marketplace-current-member.dto';
+import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
+import { MarketplaceMembershipGuard } from '../guards/marketplace-membership.guard';
+
+/**
+ * Story 1.3: тестовый whoami-эндпоинт расширения marketplace.
+ *
+ * Возвращает `MarketplaceCurrentMember` — то, что положил
+ * `MarketplaceMembershipGuard` в context (username, core_roles, marketplace_roles).
+ * Используется фронтом «Стола заказов», чтобы открыться на primary столе по
+ * роли (AC-условие: «UI открывается на primary стол по marketplace-роли»).
+ */
+@Resolver()
+@Injectable()
+export class MarketplaceMembershipResolver {
+  @Query(() => MarketplaceCurrentMemberDTO, {
+    name: 'marketplaceWhoAmI',
+    description: 'Контекст пайщика для Стола заказов: core_roles + marketplace_roles',
+  })
+  @UseGuards(GqlJwtAuthGuard, MarketplaceMembershipGuard)
+  marketplaceWhoAmI(
+    @CurrentMarketplaceMember() currentMember: IMarketplaceCurrentMember
+  ): MarketplaceCurrentMemberDTO {
+    return new MarketplaceCurrentMemberDTO(currentMember);
+  }
+}

--- a/components/controller/src/extensions/marketplace/application/resolvers/marketplace-onboarding.resolver.ts
+++ b/components/controller/src/extensions/marketplace/application/resolvers/marketplace-onboarding.resolver.ts
@@ -1,0 +1,35 @@
+import { Injectable, UseGuards } from '@nestjs/common';
+import { Query, Resolver } from '@nestjs/graphql';
+
+import { GqlJwtAuthGuard } from '~/application/auth/guards/graphql-jwt-auth.guard';
+
+import { CurrentMarketplaceMember } from '../decorators/current-marketplace-member.decorator';
+import type { IMarketplaceCurrentMember } from '../dto/marketplace-current-member.dto';
+import { MarketplaceOnboardingStateDTO } from '../dto/marketplace-onboarding-state.dto';
+import { MarketplaceMembershipGuard } from '../guards/marketplace-membership.guard';
+import { MarketplaceOnboardingService } from '../onboarding/marketplace-onboarding.service';
+
+/**
+ * Story 1.4: GraphQL endpoint L3 fallback онбординга.
+ *
+ * AC: «UI вызывает `marketplaceOnboardingState(member_id)`». В нашей модели
+ * member_id == JWT-пайщик из `MarketplaceMembershipGuard`, аргумент опущен —
+ * сервер сам берёт username из context, фронт не должен подменять.
+ */
+@Resolver()
+@Injectable()
+export class MarketplaceOnboardingResolver {
+  constructor(private readonly onboardingService: MarketplaceOnboardingService) {}
+
+  @Query(() => MarketplaceOnboardingStateDTO, {
+    name: 'marketplaceOnboardingState',
+    description:
+      'Состояние онбординга пайщика в Столе заказов: показывать ли gate или пропускать на стол',
+  })
+  @UseGuards(GqlJwtAuthGuard, MarketplaceMembershipGuard)
+  marketplaceOnboardingState(
+    @CurrentMarketplaceMember() currentMember: IMarketplaceCurrentMember
+  ): Promise<MarketplaceOnboardingStateDTO> {
+    return this.onboardingService.getOnboardingState(currentMember.username);
+  }
+}

--- a/components/controller/src/extensions/marketplace/constants/marketplace-agreement-ids.ts
+++ b/components/controller/src/extensions/marketplace/constants/marketplace-agreement-ids.ts
@@ -1,0 +1,32 @@
+/**
+ * Идентификаторы оферт расширения marketplace (Стол заказов).
+ *
+ * Локальный source-of-truth для строковых значений, которые расширение
+ * регистрирует в платформенном AgreementRegistry через
+ * `register-marketplace-in-agreement-registry.ts` (аналог Capital, Story 1.2).
+ *
+ * `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID` — `document_registry_id` шаблона
+ * оферты ЦПП «Стол заказов» в платформенной фабрике документов. До тех пор,
+ * пока Story 1.7 (one-time platform setup) не выполнена и константа не
+ * заменена на реальный `registry_id`, регистрация в AgreementRegistry
+ * пропускается с warn-логом — SignUp не предлагает оферту.
+ *
+ * После Story 1.7 правильное место для значения — `cooptypes`
+ * `Cooperative.Registry.MarketplaceOffer.registry_id` (по аналогии с
+ * `GeneratorOffer` / `BlagorostOffer`), импортировать оттуда вместо
+ * локальной константы. Сейчас держим placeholder, чтобы код был готов к
+ * подмене.
+ */
+
+export const MARKETPLACE_EXTENSION_NAME = 'market';
+
+export const MARKETPLACE_OFFER_AGREEMENT_ID = 'order_table_offer';
+
+// On-chain имя оферты «Стол заказов» в `soviet::coagreements`. Должно совпадать
+// со значением, которое контракт принимает в sndagreement/signagree — иначе
+// `get_coagreement_or_fail` упадёт «Соглашение указанного типа не найдено».
+export const MARKETPLACE_AGREEMENT_TYPE = 'order_table';
+
+// Placeholder, наполняется в Story 1.7 (one-time platform setup template'а в
+// document factory) → правильное место — `Cooperative.Registry.MarketplaceOffer.registry_id`.
+export const MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0;

--- a/components/controller/src/extensions/marketplace/constants/marketplace-agreement-ids.ts
+++ b/components/controller/src/extensions/marketplace/constants/marketplace-agreement-ids.ts
@@ -1,3 +1,5 @@
+import { Cooperative } from 'cooptypes';
+
 /**
  * Идентификаторы оферт расширения marketplace (Стол заказов).
  *
@@ -11,16 +13,9 @@
  * `w.mkt.member` (`wallets.generated.ts`) и whitelist `marketplace`-контракта.
  *
  * `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID` — `document_registry_id` шаблона
- * оферты ЦПП «Стол заказов» в платформенной фабрике документов. До тех пор,
- * пока Story 1.7 (one-time platform setup) не выполнена и константа не
- * заменена на реальный `registry_id`, регистрация в AgreementRegistry
- * пропускается с warn-логом — SignUp не предлагает оферту.
- *
- * После Story 1.7 правильное место для значения — `cooptypes`
- * `Cooperative.Registry.MarketplaceOffer.registry_id` (по аналогии с
- * `GeneratorOffer` / `BlagorostOffer`), импортировать оттуда вместо
- * локальной константы. Сейчас держим placeholder, чтобы код был готов к
- * подмене.
+ * оферты ЦПП «Стол заказов» в платформенной фабрике документов. Story 1.7
+ * разместила шаблон в `cooptypes/cooperative/registry/1100.MarketplaceOfferTemplate`;
+ * импортируется отсюда напрямую (по аналогии с Capital + GeneratorOffer/BlagorostOffer).
  */
 
 export const MARKETPLACE_EXTENSION_NAME = 'market';
@@ -33,6 +28,12 @@ export const MARKETPLACE_OFFER_AGREEMENT_ID = 'marketplace_offer';
 // `get_coagreement_or_fail` падает «Соглашение указанного типа не найдено».
 export const MARKETPLACE_AGREEMENT_TYPE = 'marketplace';
 
-// Placeholder, наполняется в Story 1.7 (one-time platform setup template'а в
-// document factory) → правильное место — `Cooperative.Registry.MarketplaceOffer.registry_id`.
-export const MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0;
+// Story 1.7: registry_id шаблона `1100.MarketplaceOfferTemplate` из cooptypes.
+// Изменение значения = миграция (новые подписи пайщиков идут на новый template);
+// финальная редакция оферты обновит только содержимое 1100.MarketplaceOfferTemplate,
+// id остаётся.
+export const MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = Cooperative.Registry.MarketplaceOfferTemplate.registry_id;
+
+// Story 1.7: registry_id инстанса `1101.MarketplaceOffer` — renderуется при
+// L2 (Story 1.11) или L3 (Story 1.4) подписании пайщиком.
+export const MARKETPLACE_OFFER_INSTANCE_REGISTRY_ID = Cooperative.Registry.MarketplaceOffer.registry_id;

--- a/components/controller/src/extensions/marketplace/constants/marketplace-agreement-ids.ts
+++ b/components/controller/src/extensions/marketplace/constants/marketplace-agreement-ids.ts
@@ -5,6 +5,11 @@
  * регистрирует в платформенном AgreementRegistry через
  * `register-marketplace-in-agreement-registry.ts` (аналог Capital, Story 1.2).
  *
+ * `MARKETPLACE_AGREEMENT_TYPE` совпадает с program-именем в контракте
+ * `lib/consts.hpp`: `_marketplace_program = "marketplace"_n` (program_id=2).
+ * `_` в `eosio::name` запрещён, поэтому имя без подчёркиваний; см. также
+ * `w.mkt.member` (`wallets.generated.ts`) и whitelist `marketplace`-контракта.
+ *
  * `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID` — `document_registry_id` шаблона
  * оферты ЦПП «Стол заказов» в платформенной фабрике документов. До тех пор,
  * пока Story 1.7 (one-time platform setup) не выполнена и константа не
@@ -20,12 +25,13 @@
 
 export const MARKETPLACE_EXTENSION_NAME = 'market';
 
-export const MARKETPLACE_OFFER_AGREEMENT_ID = 'order_table_offer';
+export const MARKETPLACE_OFFER_AGREEMENT_ID = 'marketplace_offer';
 
-// On-chain имя оферты «Стол заказов» в `soviet::coagreements`. Должно совпадать
-// со значением, которое контракт принимает в sndagreement/signagree — иначе
-// `get_coagreement_or_fail` упадёт «Соглашение указанного типа не найдено».
-export const MARKETPLACE_AGREEMENT_TYPE = 'order_table';
+// On-chain имя оферты в `soviet::coagreements`. Контракт принимает eosio::name
+// (a-z, 1-5, точка, max 12) — `_` запрещён. Значение совпадает с
+// `_marketplace_program = "marketplace"_n` (lib/consts.hpp, program_id=2), иначе
+// `get_coagreement_or_fail` падает «Соглашение указанного типа не найдено».
+export const MARKETPLACE_AGREEMENT_TYPE = 'marketplace';
 
 // Placeholder, наполняется в Story 1.7 (one-time platform setup template'а в
 // document factory) → правильное место — `Cooperative.Registry.MarketplaceOffer.registry_id`.

--- a/components/controller/src/extensions/marketplace/marketplace-extension.module.ts
+++ b/components/controller/src/extensions/marketplace/marketplace-extension.module.ts
@@ -11,6 +11,11 @@ import { config } from '~/config';
 import { IConfig, defaultConfig, Schema } from './types';
 import { MarketplaceExtensionDomainModule } from './domain/marketplace-domain.module';
 import { MarketplaceExtensionApplicationModule } from './application/marketplace-application.module';
+import {
+  AGREEMENT_REGISTRATION_PORT,
+  type AgreementRegistrationPort,
+} from '~/domain/registration/ports/agreement-registration.port';
+import { registerMarketplaceInAgreementRegistry } from './application/registration/register-marketplace-in-agreement-registry';
 
 /**
  * Optional-инжектируемый порт файлового хранилища. Имя расширения marketplace
@@ -29,6 +34,8 @@ export class MarketplacePlugin extends BaseExtModule {
   constructor(
     @Inject(EXTENSION_REPOSITORY) private readonly extensionRepository: ExtensionDomainRepository<IConfig>,
     private readonly logger: WinstonLoggerService,
+    @Inject(AGREEMENT_REGISTRATION_PORT)
+    private readonly agreementRegistrationPort: AgreementRegistrationPort,
     @Optional()
     @Inject(MARKETPLACE_FILE_STORAGE_PORT)
     private readonly fileStorage: IMarketplaceFileStoragePort | null = null
@@ -56,8 +63,36 @@ export class MarketplacePlugin extends BaseExtModule {
     };
 
     await this.initBucket();
+    this.registerInAgreementRegistry();
 
     this.logger.info('marketplace-extension готов');
+  }
+
+  /**
+   * Регистрация оферты ЦПП «Стол заказов» в платформенном AgreementRegistry
+   * (Story 1.2). Использует общий core-механизм `AgreementRegistrationPort` —
+   * тот же, через который Capital регистрирует свои оферты. Записи реестра
+   * автоматически зачищаются при `EXTENSION_APP_TERMINATE_EVENT`.
+   *
+   * Пока `MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID` остаётся placeholder'ом
+   * (Story 1.7 не выполнена) — функция возвращает false, регистрация
+   * пропускается с info-логом; SignUp не предлагает оферту marketplace.
+   */
+  private registerInAgreementRegistry(): void {
+    try {
+      const registered = registerMarketplaceInAgreementRegistry(this.agreementRegistrationPort);
+      if (registered) {
+        this.logger.info('[MARKETPLACE.REGISTRY] зарегистрирована 1 оферта marketplace');
+      } else {
+        this.logger.info(
+          '[MARKETPLACE.REGISTRY] MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID не задан (Story 1.7 не выполнена) — оферта не регистрируется'
+        );
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`Не удалось зарегистрировать marketplace в AgreementRegistry: ${message}`, stack);
+    }
   }
 
   /**

--- a/components/controller/src/extensions/marketplace/migrations/marketplace-bootstrap-v2.migration.ts
+++ b/components/controller/src/extensions/marketplace/migrations/marketplace-bootstrap-v2.migration.ts
@@ -1,0 +1,35 @@
+import type {
+  IExtensionSchemaMigration,
+  ExtensionSchemaMigrationAfterContext,
+} from '~/domain/extension/services/extension-schema-migration.service';
+import { defaultConfig, IConfig } from '../types';
+
+/**
+ * Bootstrap-миграция v2 расширения `market` (Story 1.9 — L1 онбординг).
+ *
+ * Добавляет в `extension.config` поле `coopAcceptance` (статус принятия
+ * положения ЦПП Советом). Не трогает остальные поля v1 конфига.
+ *
+ * Идемпотентна: `coopAcceptance` от существующего конфига сохраняется как
+ * есть (пользовательский accepted=true после Story 1.9 не сбрасывается),
+ * отсутствующие подполя берутся из defaultConfig.coopAcceptance.
+ */
+export const marketplaceBootstrapV2Migration: IExtensionSchemaMigration<Partial<IConfig>, IConfig> = {
+  extensionName: 'market',
+  version: 2,
+
+  migrate(oldConfig, def) {
+    return {
+      ...def,
+      ...oldConfig,
+      coopAcceptance: {
+        ...def.coopAcceptance,
+        ...(oldConfig?.coopAcceptance ?? {}),
+      },
+    };
+  },
+
+  async afterMigrate(_ctx: ExtensionSchemaMigrationAfterContext) {
+    // no-op — изменение чисто конфигурационное, без data-миграций.
+  },
+};

--- a/components/controller/src/extensions/marketplace/types.ts
+++ b/components/controller/src/extensions/marketplace/types.ts
@@ -1,28 +1,61 @@
 import { z } from 'zod';
 
+/**
+ * Story 1.9: L1-онбординг кооператива — решение совета о принятии положения ЦПП.
+ *
+ * `accepted` — флаг готовности расширения; `marketplaceCppStatus` отдаёт
+ * `'active'` если true, `'not_accepted'` если false.
+ * `document_registry_id` — id рендеренного instance положения ЦПП в
+ * платформенном registry (или 0 если рендеринг ещё не выполнен; в Эпике 8
+ * будет интегрировано с document factory).
+ * `accepted_by_board_decision_id` — id решения Совета (FR40, Эпик 8); в MVP
+ * пустая строка либо stub-значение председателя.
+ */
+export interface ICoopAcceptanceConfig {
+  accepted: boolean;
+  document_registry_id: number;
+  accepted_at: string; // ISO-8601, пустая строка = «не принято».
+  accepted_by_board_decision_id: string;
+}
+
 // Конфигурация для расширения marketplace
 export interface IConfig {
   enabled: boolean;
   lastSyncTimestamp: string;
-  // categorySyncEnabled: boolean;
-  // attributeSyncEnabled: boolean;
   debug: boolean;
+  // Story 1.9: статус принятия положения ЦПП Советом кооператива.
+  coopAcceptance: ICoopAcceptanceConfig;
 }
 
 // Дефолтные параметры конфигурации
 export const defaultConfig: IConfig = {
   enabled: true,
   lastSyncTimestamp: '',
-  // categorySyncEnabled: true,
-  // attributeSyncEnabled: true,
   debug: false,
+  coopAcceptance: {
+    accepted: false,
+    document_registry_id: 0,
+    accepted_at: '',
+    accepted_by_board_decision_id: '',
+  },
 };
 
 // Схема валидации конфигурации
 export const Schema = z.object({
   enabled: z.boolean().default(true),
   lastSyncTimestamp: z.string().default(''),
-  // categorySyncEnabled: z.boolean().default(true),
-  // attributeSyncEnabled: z.boolean().default(true),
   debug: z.boolean().default(false),
+  coopAcceptance: z
+    .object({
+      accepted: z.boolean().default(false),
+      document_registry_id: z.number().default(0),
+      accepted_at: z.string().default(''),
+      accepted_by_board_decision_id: z.string().default(''),
+    })
+    .default({
+      accepted: false,
+      document_registry_id: 0,
+      accepted_at: '',
+      accepted_by_board_decision_id: '',
+    }),
 });

--- a/components/controller/tests/unit/marketplace/core-roles-mapper.test.ts
+++ b/components/controller/tests/unit/marketplace/core-roles-mapper.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Unit-тесты mapUserRoleToCoreRoles (Story 1.3).
+ *
+ * Маппинг user.role (один из 'user'/'member'/'chairman'/'admin') в
+ * core_roles[] (['User']/['User','Member']/['User','Member','Chairman']/[]) —
+ * иерархический. Покрываем все 4 варианта AC + missing/неизвестное.
+ */
+import { mapUserRoleToCoreRoles } from '~/extensions/marketplace/application/membership/core-roles.mapper';
+
+describe('mapUserRoleToCoreRoles', () => {
+  it('обычный пайщик (user) → [User]', () => {
+    expect(mapUserRoleToCoreRoles('user')).toEqual(['User']);
+  });
+
+  it('член совета (member) → [User, Member]', () => {
+    expect(mapUserRoleToCoreRoles('member')).toEqual(['User', 'Member']);
+  });
+
+  it('председатель (chairman) → [User, Member, Chairman]', () => {
+    expect(mapUserRoleToCoreRoles('chairman')).toEqual(['User', 'Member', 'Chairman']);
+  });
+
+  it('admin или неизвестная роль → []', () => {
+    expect(mapUserRoleToCoreRoles('admin')).toEqual([]);
+    expect(mapUserRoleToCoreRoles('unknown')).toEqual([]);
+  });
+
+  it('пустая/missing роль → []', () => {
+    expect(mapUserRoleToCoreRoles(undefined)).toEqual([]);
+    expect(mapUserRoleToCoreRoles(null)).toEqual([]);
+    expect(mapUserRoleToCoreRoles('')).toEqual([]);
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-access-guard.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-access-guard.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit-тесты MarketplaceRoleGuard под новый декоратор
+ * `@RequireMarketplaceAccess(resource, action)` (Story 1.8).
+ *
+ * Покрывают:
+ *   (a) только @RequireMarketplaceAccess → guard вызывает canAccess;
+ *   (b) комбинация role + access → guard требует выполнения обоих;
+ *   (c) ни декоратора → guard разрешает;
+ *   (d) server-secret bypass;
+ *   (e) forbidden-attempt лог при отказе по access.
+ *
+ * Тесты только Role-семантики покрыты в marketplace-role-guard.test.ts.
+ */
+jest.mock('~/config/config', () => ({
+  __esModule: true,
+  default: { server_secret: 'svc-secret' },
+}));
+
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { MARKETPLACE_ACCESS_METADATA_KEY } from '~/extensions/marketplace/application/decorators/marketplace-access.decorator';
+import { MARKETPLACE_ROLES_METADATA_KEY } from '~/extensions/marketplace/application/decorators/marketplace-role.decorator';
+import { MarketplaceRoleGuard } from '~/extensions/marketplace/application/guards/marketplace-role.guard';
+
+const makeLogger = () =>
+  ({
+    setContext: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as any);
+
+function makeReflector({
+  roles,
+  access,
+}: {
+  roles?: string[];
+  access?: { resource: string; action: string };
+}): Reflector {
+  return {
+    getAllAndOverride: jest.fn().mockImplementation((key: string) => {
+      if (key === MARKETPLACE_ROLES_METADATA_KEY) return roles;
+      if (key === MARKETPLACE_ACCESS_METADATA_KEY) return access;
+      return undefined;
+    }),
+  } as any;
+}
+
+function makeCtx(req: any) {
+  const gqlCtx = { req, currentMember: req?.currentMember };
+  return {
+    getType: () => 'graphql',
+    getHandler: () => ({ name: 'handler' }) as any,
+    getClass: () => ({ name: 'Resolver' }) as any,
+    getArgs: () => [undefined, undefined, gqlCtx, undefined] as any,
+    getArgByIndex: (i: number) => [undefined, undefined, gqlCtx, undefined][i],
+    switchToHttp: () => ({ getRequest: () => req }) as any,
+    switchToRpc: () => undefined as any,
+    switchToWs: () => undefined as any,
+  };
+}
+
+describe('MarketplaceRoleGuard (Story 1.8 — access-matrix)', () => {
+  it('@RequireMarketplaceAccess Order:create, orderer → true', () => {
+    const guard = new MarketplaceRoleGuard(
+      makeReflector({ access: { resource: 'Order', action: 'create' } }),
+      makeLogger()
+    );
+    const req = {
+      headers: {},
+      currentMember: {
+        username: 'alice',
+        core_roles: ['User'],
+        marketplace_roles: ['orderer'],
+      },
+    };
+    expect(guard.canActivate(makeCtx(req) as any)).toBe(true);
+  });
+
+  it('@RequireMarketplaceAccess KU:manage, только orderer → ForbiddenException + log', () => {
+    const logger = makeLogger();
+    const guard = new MarketplaceRoleGuard(
+      makeReflector({ access: { resource: 'KU', action: 'manage' } }),
+      logger
+    );
+    const req = {
+      headers: {},
+      currentMember: {
+        username: 'alice',
+        core_roles: ['User'],
+        marketplace_roles: ['orderer'],
+      },
+    };
+    expect(() => guard.canActivate(makeCtx(req) as any)).toThrow(ForbiddenException);
+    const msg = (logger.warn as jest.Mock).mock.calls[0][0] as string;
+    expect(msg).toContain('forbidden-attempt');
+    expect(msg).toContain('requested_access=KU:manage');
+  });
+
+  it('Комбинация: @RequireMarketplaceRole admin + @RequireMarketplaceAccess Offer:moderate, admin → true', () => {
+    const guard = new MarketplaceRoleGuard(
+      makeReflector({
+        roles: ['admin'],
+        access: { resource: 'Offer', action: 'moderate' },
+      }),
+      makeLogger()
+    );
+    const req = {
+      headers: {},
+      currentMember: {
+        username: 'chair',
+        core_roles: ['User', 'Member', 'Chairman'],
+        marketplace_roles: ['orderer', 'board_readonly', 'admin', 'board'],
+      },
+    };
+    expect(guard.canActivate(makeCtx(req) as any)).toBe(true);
+  });
+
+  it('Комбинация: роль admin есть, но access не покрыт матрицей → отказ от access (логическое И)', () => {
+    const guard = new MarketplaceRoleGuard(
+      makeReflector({
+        roles: ['admin'],
+        access: { resource: 'KU', action: 'read:own-KU' }, // только operator
+      }),
+      makeLogger()
+    );
+    const req = {
+      headers: {},
+      currentMember: {
+        username: 'chair',
+        core_roles: ['User', 'Member', 'Chairman'],
+        marketplace_roles: ['orderer', 'board_readonly', 'admin', 'board'],
+      },
+    };
+    expect(() => guard.canActivate(makeCtx(req) as any)).toThrow(ForbiddenException);
+  });
+
+  it('server-secret пропускает оба требования', () => {
+    const guard = new MarketplaceRoleGuard(
+      makeReflector({
+        roles: ['admin'],
+        access: { resource: 'KU', action: 'manage' },
+      }),
+      makeLogger()
+    );
+    const req = { headers: { 'server-secret': 'svc-secret' } };
+    expect(guard.canActivate(makeCtx(req) as any)).toBe(true);
+  });
+
+  it('Ни одного декоратора → guard разрешает (membership проверяется отдельно)', () => {
+    const guard = new MarketplaceRoleGuard(makeReflector({}), makeLogger());
+    expect(guard.canActivate(makeCtx({ headers: {} }) as any)).toBe(true);
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-access-matrix.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-access-matrix.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit-тесты централизованной marketplace-access-matrix (Story 1.8).
+ *
+ * Покрывают AC:
+ *   - canAccess(roles, resource, action) учитывает ЛЮБУЮ из ролей;
+ *   - exact-match по action (`read:own` != `read`);
+ *   - roleHasAnyAction матчит базовый action и все его :квалификаторы;
+ *   - матрица содержит ожидаемые ключи для всех 6 marketplace-ролей.
+ */
+import {
+  canAccess,
+  marketplaceAccessMatrix,
+  roleHasAnyAction,
+} from '~/extensions/marketplace/application/access/marketplace-access-matrix';
+
+describe('marketplaceAccessMatrix', () => {
+  it('содержит все 6 marketplace-ролей', () => {
+    const roles = Object.keys(marketplaceAccessMatrix).sort();
+    expect(roles).toEqual([
+      'admin',
+      'board',
+      'board_readonly',
+      'offerer',
+      'operator',
+      'orderer',
+    ]);
+  });
+
+  it('orderer имеет Order:create, Order:read:own, Order:cancel:own, Offer:read', () => {
+    expect(marketplaceAccessMatrix.orderer.Order).toContain('create');
+    expect(marketplaceAccessMatrix.orderer.Order).toContain('read:own');
+    expect(marketplaceAccessMatrix.orderer.Order).toContain('cancel:own');
+    expect(marketplaceAccessMatrix.orderer.Offer).toContain('read');
+  });
+
+  it('admin имеет KU:manage и Vitrine:manage', () => {
+    expect(marketplaceAccessMatrix.admin.KU).toContain('manage');
+    expect(marketplaceAccessMatrix.admin.Vitrine).toContain('manage');
+  });
+});
+
+describe('canAccess', () => {
+  it('orderer может Order:create', () => {
+    expect(canAccess(['orderer'], 'Order', 'create')).toBe(true);
+  });
+
+  it('orderer не может Order:read:all (нотация exact-match)', () => {
+    expect(canAccess(['orderer'], 'Order', 'read:all')).toBe(false);
+  });
+
+  it('OR по ролям: пайщик [orderer, board_readonly] может Order:read:all (от board_readonly)', () => {
+    expect(canAccess(['orderer', 'board_readonly'], 'Order', 'read:all')).toBe(true);
+  });
+
+  it('admin может KU:manage, но не KU:read:own-KU (operator-specific)', () => {
+    expect(canAccess(['admin'], 'KU', 'manage')).toBe(true);
+    expect(canAccess(['admin'], 'KU', 'read:own-KU')).toBe(false);
+  });
+
+  it('roles=[] → false для любого resource:action', () => {
+    expect(canAccess([], 'Order', 'create')).toBe(false);
+  });
+
+  it('unknown resource или action → false', () => {
+    expect(canAccess(['orderer'], 'NotAResource', 'create')).toBe(false);
+    expect(canAccess(['orderer'], 'Order', 'evil-action')).toBe(false);
+  });
+});
+
+describe('roleHasAnyAction', () => {
+  it('orderer имеет ANY read на Order (есть read:own)', () => {
+    expect(roleHasAnyAction(['orderer'], 'Order', 'read')).toBe(true);
+  });
+
+  it('orderer не имеет ANY moderate на Offer', () => {
+    expect(roleHasAnyAction(['orderer'], 'Offer', 'moderate')).toBe(false);
+  });
+
+  it('admin имеет ANY moderate на Offer (есть buy moderate)', () => {
+    expect(roleHasAnyAction(['admin'], 'Offer', 'moderate')).toBe(true);
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-coop-acceptance-service.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-coop-acceptance-service.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit-тесты MarketplaceCoopAcceptanceService (Story 1.9).
+ *
+ * Покрывают AC:
+ *   (a) getStatus → 'not_accepted' пока coopAcceptance.accepted=false;
+ *   (b) accept({...}) пишет в extension.config.coopAcceptance, возвращает
+ *       'active' с переданным document_registry_id/board_decision_id;
+ *   (c) accept повторно (re-accept) — overrides предыдущее, нет дубликата;
+ *   (d) если расширения нет в БД → NotFoundException.
+ */
+import { NotFoundException } from '@nestjs/common';
+
+import { MarketplaceCoopAcceptanceService } from '~/extensions/marketplace/application/coop-acceptance/marketplace-coop-acceptance.service';
+
+const makeLogger = () =>
+  ({
+    setContext: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as any);
+
+function makeRepo(initialConfig: any = {}) {
+  const state = { name: 'market', config: { enabled: true, debug: false, ...initialConfig } };
+  const updateMock = jest.fn().mockImplementation(async (patch: any) => {
+    Object.assign(state.config, patch.config);
+    return state;
+  });
+  return {
+    findByName: jest.fn().mockImplementation(async (name: string) =>
+      name === 'market' ? state : null
+    ),
+    update: updateMock,
+    _state: state,
+  } as any;
+}
+
+describe('MarketplaceCoopAcceptanceService', () => {
+  it('getStatus → not_accepted при default coopAcceptance.accepted=false', async () => {
+    const repo = makeRepo({
+      coopAcceptance: { accepted: false, document_registry_id: 0, accepted_at: '', accepted_by_board_decision_id: '' },
+    });
+    const service = new MarketplaceCoopAcceptanceService(repo, makeLogger());
+
+    const status = await service.getStatus();
+    expect(status.status).toBe('not_accepted');
+    expect(status.document_registry_id).toBeUndefined();
+  });
+
+  it('getStatus → not_accepted даже если coopAcceptance отсутствует (fallback на default)', async () => {
+    const repo = makeRepo({}); // нет coopAcceptance вообще
+    const service = new MarketplaceCoopAcceptanceService(repo, makeLogger());
+    const status = await service.getStatus();
+    expect(status.status).toBe('not_accepted');
+  });
+
+  it('accept(input) → status=active + поля заполнены, repo.update вызван', async () => {
+    const repo = makeRepo({
+      coopAcceptance: { accepted: false, document_registry_id: 0, accepted_at: '', accepted_by_board_decision_id: '' },
+    });
+    const service = new MarketplaceCoopAcceptanceService(repo, makeLogger());
+
+    const status = await service.accept({
+      document_registry_id: 1101,
+      accepted_by_board_decision_id: 'board-decision-42',
+      accepted_at: '2026-05-14T12:00:00Z',
+    });
+
+    expect(status.status).toBe('active');
+    expect(status.document_registry_id).toBe(1101);
+    expect(status.accepted_at).toBe('2026-05-14T12:00:00Z');
+    expect(status.accepted_by_board_decision_id).toBe('board-decision-42');
+    expect(repo.update).toHaveBeenCalledTimes(1);
+    expect(repo._state.config.coopAcceptance).toEqual({
+      accepted: true,
+      document_registry_id: 1101,
+      accepted_at: '2026-05-14T12:00:00Z',
+      accepted_by_board_decision_id: 'board-decision-42',
+    });
+  });
+
+  it('accept повторно (re-accept) overrides предыдущее значение, не дубликат', async () => {
+    const repo = makeRepo({
+      coopAcceptance: {
+        accepted: true,
+        document_registry_id: 100,
+        accepted_at: '2026-05-13T00:00:00Z',
+        accepted_by_board_decision_id: 'old-decision',
+      },
+    });
+    const service = new MarketplaceCoopAcceptanceService(repo, makeLogger());
+
+    const status = await service.accept({
+      document_registry_id: 200,
+      accepted_by_board_decision_id: 'new-decision',
+      accepted_at: '2026-05-14T00:00:00Z',
+    });
+
+    expect(status.document_registry_id).toBe(200);
+    expect(status.accepted_by_board_decision_id).toBe('new-decision');
+  });
+
+  it('accept без явного accepted_at → берётся текущее время (валидный ISO)', async () => {
+    const repo = makeRepo({});
+    const service = new MarketplaceCoopAcceptanceService(repo, makeLogger());
+    const status = await service.accept({
+      document_registry_id: 1,
+      accepted_by_board_decision_id: 'x',
+    });
+    expect(status.accepted_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+  });
+
+  it('расширения нет в БД → NotFoundException для getStatus и accept', async () => {
+    const repo = {
+      findByName: jest.fn().mockResolvedValue(null),
+      update: jest.fn(),
+    } as any;
+    const service = new MarketplaceCoopAcceptanceService(repo, makeLogger());
+
+    await expect(service.getStatus()).rejects.toThrow(NotFoundException);
+    await expect(
+      service.accept({ document_registry_id: 1, accepted_by_board_decision_id: 'x' })
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-member-wallet-resolver.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-member-wallet-resolver.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit-тесты MarketplaceMemberWalletResolver (Story 1.5).
+ *
+ * Покрывают:
+ *   (a) кошелёк найден → возвращается DTO с available/blocked/membership_contribution
+ *       (значения из ProgramWalletDTO);
+ *   (b) кошелёк не найден (PG-кеш пуст, пайщик ещё не открывал main wallet)
+ *       → NotFoundException, чтобы фронт повторил после доставки delta
+ *       (CLAUDE.md запрещает RPC fallback);
+ *   (c) поля 'available'/'blocked'/'membership_contribution' с undefined нормализуются в '0'.
+ */
+
+jest.mock('~/config/config', () => ({
+  __esModule: true,
+  default: { coopname: 'voskhod' },
+}));
+
+import { NotFoundException } from '@nestjs/common';
+import { ProgramType } from '~/domain/wallet/enums/program-type.enum';
+import { MarketplaceMemberWalletResolver } from '~/extensions/marketplace/application/resolvers/marketplace-member-wallet.resolver';
+
+const makeWalletService = (wallet: any) =>
+  ({
+    getProgramWallet: jest.fn().mockResolvedValue(wallet),
+  } as any);
+
+const member = {
+  username: 'alice',
+  core_roles: ['User'],
+  marketplace_roles: [],
+};
+
+describe('MarketplaceMemberWalletResolver', () => {
+  it('кошелёк найден → DTO с available/blocked/membership_contribution', async () => {
+    const walletService = makeWalletService({
+      available: '125.0000 RUB',
+      blocked: '5.0000 RUB',
+      membership_contribution: '300.0000 RUB',
+    });
+    const resolver = new MarketplaceMemberWalletResolver(walletService);
+
+    const dto = await resolver.marketplaceMemberWallet(member);
+
+    expect(walletService.getProgramWallet).toHaveBeenCalledWith({
+      coopname: 'voskhod',
+      username: 'alice',
+      program_type: ProgramType.MAIN,
+    });
+    expect(dto.username).toBe('alice');
+    expect(dto.coopname).toBe('voskhod');
+    expect(dto.contract).toBe('wallet');
+    expect(dto.available).toBe('125.0000 RUB');
+    expect(dto.blocked).toBe('5.0000 RUB');
+    expect(dto.membership_contribution).toBe('300.0000 RUB');
+  });
+
+  it('кошелёк не найден → NotFoundException', async () => {
+    const walletService = makeWalletService(null);
+    const resolver = new MarketplaceMemberWalletResolver(walletService);
+
+    await expect(resolver.marketplaceMemberWallet(member)).rejects.toThrow(NotFoundException);
+  });
+
+  it('поля undefined нормализуются в "0"', async () => {
+    const walletService = makeWalletService({
+      available: undefined,
+      blocked: undefined,
+      membership_contribution: undefined,
+    });
+    const resolver = new MarketplaceMemberWalletResolver(walletService);
+
+    const dto = await resolver.marketplaceMemberWallet(member);
+
+    expect(dto.available).toBe('0');
+    expect(dto.blocked).toBe('0');
+    expect(dto.membership_contribution).toBe('0');
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-membership-guard.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-membership-guard.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit-тесты MarketplaceMembershipGuard (Story 1.3).
+ *
+ * Покрывают AC:
+ *   (a) пайщик с user.role='user', status=active → guard пропускает, в
+ *       request.currentMember / ctx.currentMember лежит { core_roles:['User'],
+ *       marketplace_roles:[] };
+ *   (b) member и chairman дают расширенный core_roles;
+ *   (c) status != active → ForbiddenException (HTTP 403 «Доступ только для
+ *       пайщиков кооператива»);
+ *   (d) no user → UnauthorizedException (HTTP 401);
+ *   (e) server-secret bypass — guard true, currentMember не выставлен.
+ */
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+
+import { MarketplaceMembershipGuard } from '~/extensions/marketplace/application/guards/marketplace-membership.guard';
+
+jest.mock('~/config/config', () => ({
+  __esModule: true,
+  default: {
+    server_secret: 'test-secret',
+  },
+}));
+
+function makeCtx(req: any) {
+  const gqlCtx = { req, currentMember: undefined as any };
+  return {
+    getType: () => 'graphql',
+    getHandler: () => undefined,
+    getClass: () => undefined,
+    getArgs: () => [undefined, undefined, gqlCtx, undefined],
+    getArgByIndex: (i: number) => [undefined, undefined, gqlCtx, undefined][i],
+    switchToHttp: () => ({ getRequest: () => req }) as any,
+    switchToRpc: () => undefined as any,
+    switchToWs: () => undefined as any,
+    _gqlCtx: gqlCtx,
+  };
+}
+
+describe('MarketplaceMembershipGuard', () => {
+  let guard: MarketplaceMembershipGuard;
+
+  beforeEach(() => {
+    guard = new MarketplaceMembershipGuard();
+  });
+
+  it('user.role=user, status=active → пропускает, в ctx [User]', () => {
+    const req = { user: { username: 'alice', role: 'user', status: 'active' }, headers: {} };
+    const ctx = makeCtx(req);
+
+    expect(guard.canActivate(ctx as any)).toBe(true);
+    expect((ctx as any)._gqlCtx.currentMember).toEqual({
+      username: 'alice',
+      core_roles: ['User'],
+      marketplace_roles: [],
+    });
+    expect(req).toHaveProperty('currentMember');
+  });
+
+  it('user.role=member, status=active → core_roles [User, Member]', () => {
+    const req = { user: { username: 'bob', role: 'member', status: 'active' }, headers: {} };
+    const ctx = makeCtx(req);
+    expect(guard.canActivate(ctx as any)).toBe(true);
+    expect((ctx as any)._gqlCtx.currentMember.core_roles).toEqual(['User', 'Member']);
+  });
+
+  it('user.role=chairman, status=active → core_roles [User, Member, Chairman]', () => {
+    const req = { user: { username: 'chair', role: 'chairman', status: 'active' }, headers: {} };
+    const ctx = makeCtx(req);
+    expect(guard.canActivate(ctx as any)).toBe(true);
+    expect((ctx as any)._gqlCtx.currentMember.core_roles).toEqual(['User', 'Member', 'Chairman']);
+  });
+
+  it('status != active → 403 Forbidden «Доступ только для пайщиков кооператива»', () => {
+    const req = { user: { username: 'alice', role: 'user', status: '4_Registered' }, headers: {} };
+    const ctx = makeCtx(req);
+    expect(() => guard.canActivate(ctx as any)).toThrow(ForbiddenException);
+    expect(() => guard.canActivate(ctx as any)).toThrow('Доступ только для пайщиков кооператива');
+  });
+
+  it('нет user (нет JWT) → 401 Unauthorized', () => {
+    const req = { headers: {} };
+    const ctx = makeCtx(req);
+    expect(() => guard.canActivate(ctx as any)).toThrow(UnauthorizedException);
+  });
+
+  it('server-secret bypass → true, currentMember не выставляется', () => {
+    const req = { headers: { 'server-secret': 'test-secret' } };
+    const ctx = makeCtx(req);
+    expect(guard.canActivate(ctx as any)).toBe(true);
+    expect((ctx as any)._gqlCtx.currentMember).toBeUndefined();
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-membership-guard.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-membership-guard.test.ts
@@ -44,7 +44,7 @@ describe('MarketplaceMembershipGuard', () => {
     guard = new MarketplaceMembershipGuard();
   });
 
-  it('user.role=user, status=active → пропускает, в ctx [User]', () => {
+  it('user.role=user, status=active → пропускает, ctx [User] + marketplace_roles=[orderer]', () => {
     const req = { user: { username: 'alice', role: 'user', status: 'active' }, headers: {} };
     const ctx = makeCtx(req);
 
@@ -52,23 +52,33 @@ describe('MarketplaceMembershipGuard', () => {
     expect((ctx as any)._gqlCtx.currentMember).toEqual({
       username: 'alice',
       core_roles: ['User'],
-      marketplace_roles: [],
+      marketplace_roles: ['orderer'],
     });
     expect(req).toHaveProperty('currentMember');
   });
 
-  it('user.role=member, status=active → core_roles [User, Member]', () => {
+  it('user.role=member, status=active → core_roles [User, Member] + marketplace_roles [orderer, board_readonly]', () => {
     const req = { user: { username: 'bob', role: 'member', status: 'active' }, headers: {} };
     const ctx = makeCtx(req);
     expect(guard.canActivate(ctx as any)).toBe(true);
     expect((ctx as any)._gqlCtx.currentMember.core_roles).toEqual(['User', 'Member']);
+    expect((ctx as any)._gqlCtx.currentMember.marketplace_roles).toEqual([
+      'orderer',
+      'board_readonly',
+    ]);
   });
 
-  it('user.role=chairman, status=active → core_roles [User, Member, Chairman]', () => {
+  it('user.role=chairman, status=active → core_roles [User, Member, Chairman] + marketplace_roles полный набор', () => {
     const req = { user: { username: 'chair', role: 'chairman', status: 'active' }, headers: {} };
     const ctx = makeCtx(req);
     expect(guard.canActivate(ctx as any)).toBe(true);
     expect((ctx as any)._gqlCtx.currentMember.core_roles).toEqual(['User', 'Member', 'Chairman']);
+    expect((ctx as any)._gqlCtx.currentMember.marketplace_roles).toEqual([
+      'orderer',
+      'board_readonly',
+      'admin',
+      'board',
+    ]);
   });
 
   it('status != active → 403 Forbidden «Доступ только для пайщиков кооператива»', () => {

--- a/components/controller/tests/unit/marketplace/marketplace-onboarding-service.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-onboarding-service.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit-тесты MarketplaceOnboardingService (Story 1.4).
+ *
+ * Покрывают AC:
+ *   (a) MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0 (Story 1.7 не выполнена)
+ *       → requires_gate=false, source='not_configured';
+ *   (b) есть подписанная оферта marketplace в core `soviet::agreements3`
+ *       → requires_gate=false, source='agreement_signed', completed_at/agreement_id
+ *       заполнены;
+ *   (c) подписи нет → requires_gate=true, source='gate_required'.
+ *
+ * Для случая (b/c) подменяем константу через jest.doMock — она captured
+ * сервисом в момент вызова, не на import-time.
+ */
+
+const makeAgreement = (overrides: any = {}) => ({
+  id: 42,
+  type: 'marketplace',
+  draft_id: 7,
+  username: 'alice',
+  coopname: 'voskhod',
+  updated_at: '2026-05-14T12:00:00Z',
+  ...overrides,
+});
+
+const makeRepo = (agreements: any[]) =>
+  ({
+    findByUsername: jest.fn().mockResolvedValue(agreements),
+  } as any);
+
+const makeLogger = () =>
+  ({
+    setContext: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as any);
+
+describe('MarketplaceOnboardingService.getOnboardingState', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('placeholder=0 (Story 1.7 не выполнена) → requires_gate=false, source=not_configured', async () => {
+    // дефолтная константа = 0 (см. marketplace-agreement-ids.ts)
+    const { MarketplaceOnboardingService } = await import(
+      '~/extensions/marketplace/application/onboarding/marketplace-onboarding.service'
+    );
+    const repo = makeRepo([]);
+    const service = new MarketplaceOnboardingService(repo, makeLogger());
+
+    const state = await service.getOnboardingState('alice');
+    expect(state.requires_gate).toBe(false);
+    expect(state.source).toBe('not_configured');
+    expect(state.template_registry_id).toBe(0);
+    expect(repo.findByUsername).not.toHaveBeenCalled();
+  });
+
+  it('подпись marketplace есть → requires_gate=false, source=agreement_signed, completed_at/agreement_id заполнены', async () => {
+    jest.doMock('~/extensions/marketplace/constants/marketplace-agreement-ids', () => ({
+      __esModule: true,
+      MARKETPLACE_EXTENSION_NAME: 'market',
+      MARKETPLACE_OFFER_AGREEMENT_ID: 'marketplace_offer',
+      MARKETPLACE_AGREEMENT_TYPE: 'marketplace',
+      MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID: 7,
+    }));
+
+    const { MarketplaceOnboardingService } = await import(
+      '~/extensions/marketplace/application/onboarding/marketplace-onboarding.service'
+    );
+    const repo = makeRepo([makeAgreement({ draft_id: 7 })]);
+    const service = new MarketplaceOnboardingService(repo, makeLogger());
+
+    const state = await service.getOnboardingState('alice');
+    expect(state.requires_gate).toBe(false);
+    expect(state.source).toBe('agreement_signed');
+    expect(state.template_registry_id).toBe(7);
+    expect(state.agreement_id).toBe(42);
+    expect(state.completed_at).toBe('2026-05-14T12:00:00Z');
+    expect(repo.findByUsername).toHaveBeenCalledWith('alice');
+  });
+
+  it('подписи нет → requires_gate=true, source=gate_required', async () => {
+    jest.doMock('~/extensions/marketplace/constants/marketplace-agreement-ids', () => ({
+      __esModule: true,
+      MARKETPLACE_EXTENSION_NAME: 'market',
+      MARKETPLACE_OFFER_AGREEMENT_ID: 'marketplace_offer',
+      MARKETPLACE_AGREEMENT_TYPE: 'marketplace',
+      MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID: 7,
+    }));
+
+    const { MarketplaceOnboardingService } = await import(
+      '~/extensions/marketplace/application/onboarding/marketplace-onboarding.service'
+    );
+    const repo = makeRepo([
+      makeAgreement({ type: 'capital', draft_id: 999 }), // не marketplace — игнор
+      makeAgreement({ type: 'marketplace', draft_id: 8 }), // другой шаблон — игнор
+    ]);
+    const service = new MarketplaceOnboardingService(repo, makeLogger());
+
+    const state = await service.getOnboardingState('alice');
+    expect(state.requires_gate).toBe(true);
+    expect(state.source).toBe('gate_required');
+    expect(state.template_registry_id).toBe(7);
+    expect(state.agreement_id).toBeUndefined();
+  });
+
+  it('запись marketplace без draft_id (если контракт не проставил) считается совпадающей по type', async () => {
+    jest.doMock('~/extensions/marketplace/constants/marketplace-agreement-ids', () => ({
+      __esModule: true,
+      MARKETPLACE_EXTENSION_NAME: 'market',
+      MARKETPLACE_OFFER_AGREEMENT_ID: 'marketplace_offer',
+      MARKETPLACE_AGREEMENT_TYPE: 'marketplace',
+      MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID: 7,
+    }));
+
+    const { MarketplaceOnboardingService } = await import(
+      '~/extensions/marketplace/application/onboarding/marketplace-onboarding.service'
+    );
+    const repo = makeRepo([makeAgreement({ type: 'marketplace', draft_id: undefined, id: 99 })]);
+    const service = new MarketplaceOnboardingService(repo, makeLogger());
+
+    const state = await service.getOnboardingState('alice');
+    expect(state.requires_gate).toBe(false);
+    expect(state.agreement_id).toBe(99);
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-onboarding-service.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-onboarding-service.test.ts
@@ -42,8 +42,14 @@ describe('MarketplaceOnboardingService.getOnboardingState', () => {
     jest.resetModules();
   });
 
-  it('placeholder=0 (Story 1.7 не выполнена) → requires_gate=false, source=not_configured', async () => {
-    // дефолтная константа = 0 (см. marketplace-agreement-ids.ts)
+  it('placeholder=0 (rollback Story 1.7) → requires_gate=false, source=not_configured', async () => {
+    jest.doMock('~/extensions/marketplace/constants/marketplace-agreement-ids', () => ({
+      __esModule: true,
+      MARKETPLACE_EXTENSION_NAME: 'market',
+      MARKETPLACE_OFFER_AGREEMENT_ID: 'marketplace_offer',
+      MARKETPLACE_AGREEMENT_TYPE: 'marketplace',
+      MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID: 0,
+    }));
     const { MarketplaceOnboardingService } = await import(
       '~/extensions/marketplace/application/onboarding/marketplace-onboarding.service'
     );
@@ -55,6 +61,20 @@ describe('MarketplaceOnboardingService.getOnboardingState', () => {
     expect(state.source).toBe('not_configured');
     expect(state.template_registry_id).toBe(0);
     expect(repo.findByUsername).not.toHaveBeenCalled();
+  });
+
+  it('Story 1.7 размещена (template_registry_id=1100 из cooptypes), подписи нет → requires_gate=true', async () => {
+    jest.dontMock('~/extensions/marketplace/constants/marketplace-agreement-ids');
+    const { MarketplaceOnboardingService } = await import(
+      '~/extensions/marketplace/application/onboarding/marketplace-onboarding.service'
+    );
+    const repo = makeRepo([]);
+    const service = new MarketplaceOnboardingService(repo, makeLogger());
+
+    const state = await service.getOnboardingState('alice');
+    expect(state.template_registry_id).toBe(1100);
+    expect(state.requires_gate).toBe(true);
+    expect(state.source).toBe('gate_required');
   });
 
   it('подпись marketplace есть → requires_gate=false, source=agreement_signed, completed_at/agreement_id заполнены', async () => {

--- a/components/controller/tests/unit/marketplace/marketplace-plugin-initialize.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-plugin-initialize.test.ts
@@ -26,11 +26,19 @@ const makeRepo = (record: any = { name: 'market', config: {}, enabled: true }) =
     findByName: jest.fn().mockResolvedValue(record),
   } as any);
 
+const makeAgreementPort = () =>
+  ({
+    registerAgreement: jest.fn(),
+    unregisterAgreement: jest.fn(),
+    registerProgram: jest.fn(),
+    unregisterProgram: jest.fn(),
+  } as any);
+
 describe('MarketplacePlugin.initialize', () => {
   it('пишет warn о fallback и продолжает install, если file-storage не подключён', async () => {
     const logger = makeLogger();
     const repo = makeRepo();
-    const plugin = new MarketplacePlugin(repo, logger, null);
+    const plugin = new MarketplacePlugin(repo, logger, makeAgreementPort(), null);
 
     await plugin.initialize();
 
@@ -47,7 +55,7 @@ describe('MarketplacePlugin.initialize', () => {
     const logger = makeLogger();
     const repo = makeRepo();
     const fileStorage = { ensureBucket: jest.fn().mockResolvedValue(undefined) };
-    const plugin = new MarketplacePlugin(repo, logger, fileStorage);
+    const plugin = new MarketplacePlugin(repo, logger, makeAgreementPort(), fileStorage);
 
     await plugin.initialize();
 
@@ -61,13 +69,13 @@ describe('MarketplacePlugin.initialize', () => {
   it('бросает «Конфиг не найден» если в БД нет записи market', async () => {
     const logger = makeLogger();
     const repo = makeRepo(null);
-    const plugin = new MarketplacePlugin(repo, logger, null);
+    const plugin = new MarketplacePlugin(repo, logger, makeAgreementPort(), null);
 
     await expect(plugin.initialize()).rejects.toThrow('Конфиг не найден');
   });
 
   it('расширение зарегистрировано под именем `market` (совпадает с ключом AppRegistry)', () => {
-    const plugin = new MarketplacePlugin(makeRepo(), makeLogger(), null);
+    const plugin = new MarketplacePlugin(makeRepo(), makeLogger(), makeAgreementPort(), null);
     expect(plugin.name).toBe('market');
   });
 });

--- a/components/controller/tests/unit/marketplace/marketplace-plugin-register.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-plugin-register.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit-тесты registerMarketplaceInAgreementRegistry (Story 1.2).
+ *
+ * Чистая функция — не тянет за собой импорт MarketplacePlugin (там цепочка
+ * с lifecycle, file-storage порт и т.д., как и в capital-plugin-register.test.ts).
+ *
+ * Покрывают:
+ *   (a) MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0 (placeholder, Story 1.7
+ *       не выполнена) → port не вызывается, функция возвращает false;
+ *   (b) Когда константа > 0 — registerAgreement вызван один раз с
+ *       корректным spec. Поскольку константа сейчас захардкожена в 0, в
+ *       этом кейсе проверяем поведение через вызов port напрямую с
+ *       другой spec'ой (что соответствует тому, как Capital проверяет
+ *       выходные данные).
+ *   (c) повторный вызов воспроизводит те же register-вызовы (реальная
+ *       идемпотентность гарантируется AgreementRegistryService).
+ */
+
+import {
+  MARKETPLACE_AGREEMENT_TYPE,
+  MARKETPLACE_EXTENSION_NAME,
+  MARKETPLACE_OFFER_AGREEMENT_ID,
+  MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID,
+} from '~/extensions/marketplace/constants/marketplace-agreement-ids';
+import { registerMarketplaceInAgreementRegistry } from '~/extensions/marketplace/application/registration/register-marketplace-in-agreement-registry';
+
+function makePortStub() {
+  return {
+    registerAgreement: jest.fn(),
+    unregisterAgreement: jest.fn(),
+    registerProgram: jest.fn(),
+    unregisterProgram: jest.fn(),
+  };
+}
+
+describe('registerMarketplaceInAgreementRegistry', () => {
+  it('возвращает false и не зовёт port пока MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0 (Story 1.7 не выполнена)', () => {
+    const port = makePortStub();
+
+    const ok = registerMarketplaceInAgreementRegistry(port as any);
+
+    expect(MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID).toBe(0);
+    expect(ok).toBe(false);
+    expect(port.registerAgreement).not.toHaveBeenCalled();
+    expect(port.registerProgram).not.toHaveBeenCalled();
+  });
+
+  it('константы используют согласованные имена для on-chain и реестра', () => {
+    expect(MARKETPLACE_EXTENSION_NAME).toBe('market');
+    expect(MARKETPLACE_OFFER_AGREEMENT_ID).toBe('order_table_offer');
+    expect(MARKETPLACE_AGREEMENT_TYPE).toBe('order_table');
+  });
+
+  it('программы для marketplace MVP не регистрируются (Стол заказов — ЦПП без program-надстройки)', () => {
+    const port = makePortStub();
+    registerMarketplaceInAgreementRegistry(port as any);
+    expect(port.registerProgram).not.toHaveBeenCalled();
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-plugin-register.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-plugin-register.test.ts
@@ -47,8 +47,10 @@ describe('registerMarketplaceInAgreementRegistry', () => {
 
   it('константы используют согласованные имена для on-chain и реестра', () => {
     expect(MARKETPLACE_EXTENSION_NAME).toBe('market');
-    expect(MARKETPLACE_OFFER_AGREEMENT_ID).toBe('order_table_offer');
-    expect(MARKETPLACE_AGREEMENT_TYPE).toBe('order_table');
+    expect(MARKETPLACE_OFFER_AGREEMENT_ID).toBe('marketplace_offer');
+    // eosio::name: max 12 chars, без `_`; совпадает с _marketplace_program в lib/consts.hpp.
+    expect(MARKETPLACE_AGREEMENT_TYPE).toBe('marketplace');
+    expect(MARKETPLACE_AGREEMENT_TYPE).toMatch(/^[.a-z1-5]{1,12}$/);
   });
 
   it('программы для marketplace MVP не регистрируются (Стол заказов — ЦПП без program-надстройки)', () => {

--- a/components/controller/tests/unit/marketplace/marketplace-plugin-register.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-plugin-register.test.ts
@@ -1,19 +1,16 @@
 /**
- * Unit-тесты registerMarketplaceInAgreementRegistry (Story 1.2).
- *
- * Чистая функция — не тянет за собой импорт MarketplacePlugin (там цепочка
- * с lifecycle, file-storage порт и т.д., как и в capital-plugin-register.test.ts).
+ * Unit-тесты registerMarketplaceInAgreementRegistry (Story 1.2 + Story 1.7).
  *
  * Покрывают:
- *   (a) MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0 (placeholder, Story 1.7
- *       не выполнена) → port не вызывается, функция возвращает false;
- *   (b) Когда константа > 0 — registerAgreement вызван один раз с
- *       корректным spec. Поскольку константа сейчас захардкожена в 0, в
- *       этом кейсе проверяем поведение через вызов port напрямую с
- *       другой spec'ой (что соответствует тому, как Capital проверяет
- *       выходные данные).
- *   (c) повторный вызов воспроизводит те же register-вызовы (реальная
- *       идемпотентность гарантируется AgreementRegistryService).
+ *   (a) реальный template_registry_id из cooptypes (Story 1.7 выполнена,
+ *       MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 1100) → port.registerAgreement
+ *       вызывается × 1, функция возвращает true.
+ *   (b) если константу принудительно занулить (placeholder режим до Story 1.7) →
+ *       port не вызывается, функция возвращает false. Это историческое
+ *       поведение, тест зафиксирован для гарантии будущей деградации (например,
+ *       при rollback Story 1.7).
+ *   (c) константы согласованы с on-chain именами (eosio::name regex).
+ *   (d) programs для marketplace MVP не регистрируются.
  */
 
 import {
@@ -34,15 +31,36 @@ function makePortStub() {
 }
 
 describe('registerMarketplaceInAgreementRegistry', () => {
-  it('возвращает false и не зовёт port пока MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID = 0 (Story 1.7 не выполнена)', () => {
+  it('Story 1.7 размещён template — registry_id из cooptypes (1100), port.registerAgreement × 1', () => {
     const port = makePortStub();
 
     const ok = registerMarketplaceInAgreementRegistry(port as any);
 
-    expect(MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID).toBe(0);
+    expect(MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID).toBe(1100);
+    expect(ok).toBe(true);
+    expect(port.registerAgreement).toHaveBeenCalledTimes(1);
+    const spec = port.registerAgreement.mock.calls[0][0];
+    expect(spec.id).toBe(MARKETPLACE_OFFER_AGREEMENT_ID);
+    expect(spec.registry_id).toBe(MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID);
+    expect(spec.agreement_type).toBe(MARKETPLACE_AGREEMENT_TYPE);
+    expect(spec.extension_name).toBe(MARKETPLACE_EXTENSION_NAME);
+  });
+
+  it('rollback Story 1.7 (template_registry_id = 0) → port не вызывается, false', () => {
+    jest.resetModules();
+    jest.doMock('~/extensions/marketplace/constants/marketplace-agreement-ids', () => ({
+      __esModule: true,
+      MARKETPLACE_EXTENSION_NAME: 'market',
+      MARKETPLACE_OFFER_AGREEMENT_ID: 'marketplace_offer',
+      MARKETPLACE_AGREEMENT_TYPE: 'marketplace',
+      MARKETPLACE_OFFER_TEMPLATE_REGISTRY_ID: 0,
+    }));
+    const { registerMarketplaceInAgreementRegistry: reg } = require('~/extensions/marketplace/application/registration/register-marketplace-in-agreement-registry');
+    const port = makePortStub();
+    const ok = reg(port as any);
     expect(ok).toBe(false);
     expect(port.registerAgreement).not.toHaveBeenCalled();
-    expect(port.registerProgram).not.toHaveBeenCalled();
+    jest.dontMock('~/extensions/marketplace/constants/marketplace-agreement-ids');
   });
 
   it('константы используют согласованные имена для on-chain и реестра', () => {

--- a/components/controller/tests/unit/marketplace/marketplace-role-guard.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-role-guard.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit-тесты MarketplaceRoleGuard (Story 1.6).
+ *
+ * Покрывают AC:
+ *   (a) роль присутствует → guard true;
+ *   (b) роль отсутствует → ForbiddenException с сообщением AC
+ *       "Forbidden: marketplace role 'admin' required, member has [...]"
+ *       + warn-лог "forbidden-attempt: ...";
+ *   (c) декоратор не задан (нет @RequireMarketplaceRole) → guard true;
+ *   (d) server-secret bypass → true даже при отсутствии currentMember;
+ *   (e) нет currentMember при заданном декораторе → Forbidden (рассогласование
+ *       UseGuards).
+ */
+jest.mock('~/config/config', () => ({
+  __esModule: true,
+  default: { server_secret: 'svc-secret' },
+}));
+
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { MARKETPLACE_ROLES_METADATA_KEY } from '~/extensions/marketplace/application/decorators/marketplace-role.decorator';
+import { MarketplaceRoleGuard } from '~/extensions/marketplace/application/guards/marketplace-role.guard';
+
+const makeLogger = () =>
+  ({
+    setContext: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as any);
+
+function makeCtx({ req, requiredRoles }: { req: any; requiredRoles?: string[] }) {
+  const handlerName = 'someHandler';
+  const className = 'SomeResolver';
+  const gqlCtx = { req, currentMember: req?.currentMember };
+  return {
+    getType: () => 'graphql',
+    getHandler: () => ({ name: handlerName }) as any,
+    getClass: () => ({ name: className }) as any,
+    getArgs: () => [undefined, undefined, gqlCtx, undefined] as any,
+    getArgByIndex: (i: number) => [undefined, undefined, gqlCtx, undefined][i],
+    switchToHttp: () => ({ getRequest: () => req }) as any,
+    switchToRpc: () => undefined as any,
+    switchToWs: () => undefined as any,
+    _gqlCtx: gqlCtx,
+    _requiredRoles: requiredRoles,
+  };
+}
+
+function makeReflector(requiredRoles?: string[]): Reflector {
+  return {
+    getAllAndOverride: jest.fn().mockReturnValue(requiredRoles),
+  } as any;
+}
+
+describe('MarketplaceRoleGuard', () => {
+  it('декоратор @RequireMarketplaceRole не задан → guard true', () => {
+    const guard = new MarketplaceRoleGuard(makeReflector(undefined), makeLogger());
+    const ctx = makeCtx({ req: { headers: {} } });
+    expect(guard.canActivate(ctx as any)).toBe(true);
+  });
+
+  it('decoratoр пустой массив → guard true', () => {
+    const guard = new MarketplaceRoleGuard(makeReflector([]), makeLogger());
+    const ctx = makeCtx({ req: { headers: {} } });
+    expect(guard.canActivate(ctx as any)).toBe(true);
+  });
+
+  it('requested role в marketplace_roles → guard true', () => {
+    const guard = new MarketplaceRoleGuard(makeReflector(['admin']), makeLogger());
+    const req = {
+      headers: {},
+      user: { username: 'chair', role: 'chairman', status: 'active' },
+      currentMember: {
+        username: 'chair',
+        core_roles: ['User', 'Member', 'Chairman'],
+        marketplace_roles: ['orderer', 'board_readonly', 'admin', 'board'],
+      },
+    };
+    const ctx = makeCtx({ req, requiredRoles: ['admin'] });
+    expect(guard.canActivate(ctx as any)).toBe(true);
+  });
+
+  it('OR-семантика: одна из ролей хватает → true', () => {
+    const guard = new MarketplaceRoleGuard(makeReflector(['admin', 'board_readonly']), makeLogger());
+    const req = {
+      headers: {},
+      currentMember: {
+        username: 'm',
+        core_roles: ['User', 'Member'],
+        marketplace_roles: ['orderer', 'board_readonly'],
+      },
+    };
+    const ctx = makeCtx({ req });
+    expect(guard.canActivate(ctx as any)).toBe(true);
+  });
+
+  it('роль отсутствует → ForbiddenException + warn-лог forbidden-attempt', () => {
+    const logger = makeLogger();
+    const guard = new MarketplaceRoleGuard(makeReflector(['admin']), logger);
+    const req = {
+      headers: {},
+      currentMember: {
+        username: 'alice',
+        core_roles: ['User'],
+        marketplace_roles: ['orderer'],
+      },
+    };
+    const ctx = makeCtx({ req });
+
+    expect(() => guard.canActivate(ctx as any)).toThrow(ForbiddenException);
+    try {
+      guard.canActivate(ctx as any);
+    } catch (e: any) {
+      expect(e.message).toContain("Forbidden: marketplace role 'admin' required");
+      expect(e.message).toContain('member has [orderer]');
+    }
+
+    expect(logger.warn).toHaveBeenCalled();
+    const message = (logger.warn as jest.Mock).mock.calls[0][0] as string;
+    expect(message).toContain('forbidden-attempt');
+    expect(message).toContain('member=alice');
+    expect(message).toContain('requested_role=[admin]');
+    expect(message).toContain('actual_marketplace_roles=[orderer]');
+    expect(message).toContain('actual_core_roles=[User]');
+  });
+
+  it('server-secret → true даже без currentMember', () => {
+    const guard = new MarketplaceRoleGuard(makeReflector(['admin']), makeLogger());
+    const ctx = makeCtx({ req: { headers: { 'server-secret': 'svc-secret' } } });
+    expect(guard.canActivate(ctx as any)).toBe(true);
+  });
+
+  it('нет currentMember + декоратор задан → ForbiddenException (рассогласование UseGuards)', () => {
+    const guard = new MarketplaceRoleGuard(makeReflector(['admin']), makeLogger());
+    const ctx = makeCtx({ req: { headers: {} } });
+    expect(() => guard.canActivate(ctx as any)).toThrow(ForbiddenException);
+  });
+
+  it('Decorator-helper RequireMarketplaceRole пишет метаданные', () => {
+    const target = {};
+    const descriptor = { value: () => undefined };
+    const required = ['admin', 'board'] as const;
+    const factory = require('~/extensions/marketplace/application/decorators/marketplace-role.decorator')
+      .RequireMarketplaceRole;
+    const decorate = factory(...required);
+    decorate(target, 'someHandler', descriptor);
+    expect(Reflect.getMetadata(MARKETPLACE_ROLES_METADATA_KEY, descriptor.value)).toEqual([
+      'admin',
+      'board',
+    ]);
+  });
+});

--- a/components/controller/tests/unit/marketplace/marketplace-role-guard.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-role-guard.test.ts
@@ -51,7 +51,14 @@ function makeCtx({ req, requiredRoles }: { req: any; requiredRoles?: string[] })
 
 function makeReflector(requiredRoles?: string[]): Reflector {
   return {
-    getAllAndOverride: jest.fn().mockReturnValue(requiredRoles),
+    getAllAndOverride: jest.fn().mockImplementation((key: string) => {
+      // Story 1.6 fixture: возвращает requiredRoles только для marketplace_roles
+      // декоратора. Декоратор marketplace_access (Story 1.8) не задан в этих
+      // кейсах — отдаём undefined, чтобы Guard не пытался канонически
+      // парсить «requiredRoles» как `{resource, action}`.
+      if (key === 'marketplace_roles') return requiredRoles;
+      return undefined;
+    }),
   } as any;
 }
 

--- a/components/controller/tests/unit/marketplace/marketplace-roles-mapper.test.ts
+++ b/components/controller/tests/unit/marketplace/marketplace-roles-mapper.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit-тесты mapCoreRolesToMarketplaceRoles (Story 1.6).
+ *
+ * Покрывают matrix-кейсы AC: все 4 варианта core_roles × все варианты
+ * context-флагов (isOfferer/isKuChairman).
+ */
+import { mapCoreRolesToMarketplaceRoles } from '~/extensions/marketplace/application/membership/marketplace-roles.mapper';
+
+describe('mapCoreRolesToMarketplaceRoles', () => {
+  it('обычный пайщик [User] → [orderer]', () => {
+    expect(mapCoreRolesToMarketplaceRoles(['User'])).toEqual(['orderer']);
+  });
+
+  it('[User] + isOfferer → [orderer, offerer]', () => {
+    expect(mapCoreRolesToMarketplaceRoles(['User'], { isOfferer: true })).toEqual([
+      'orderer',
+      'offerer',
+    ]);
+  });
+
+  it('[User] + isKuChairman → [orderer, operator]', () => {
+    expect(mapCoreRolesToMarketplaceRoles(['User'], { isKuChairman: true })).toEqual([
+      'orderer',
+      'operator',
+    ]);
+  });
+
+  it('[User, Member] → [orderer, board_readonly]', () => {
+    expect(mapCoreRolesToMarketplaceRoles(['User', 'Member'])).toEqual([
+      'orderer',
+      'board_readonly',
+    ]);
+  });
+
+  it('[User, Member, Chairman] → [orderer, board_readonly, admin, board]', () => {
+    expect(mapCoreRolesToMarketplaceRoles(['User', 'Member', 'Chairman'])).toEqual([
+      'orderer',
+      'board_readonly',
+      'admin',
+      'board',
+    ]);
+  });
+
+  it('[User, Member, Chairman] + оба флага → полный набор', () => {
+    expect(
+      mapCoreRolesToMarketplaceRoles(['User', 'Member', 'Chairman'], {
+        isOfferer: true,
+        isKuChairman: true,
+      })
+    ).toEqual(['orderer', 'offerer', 'operator', 'board_readonly', 'admin', 'board']);
+  });
+
+  it('Без User в core_roles (admin платформы) → []', () => {
+    expect(mapCoreRolesToMarketplaceRoles([])).toEqual([]);
+    expect(mapCoreRolesToMarketplaceRoles([], { isOfferer: true })).toEqual([]);
+  });
+});

--- a/components/cooptypes/src/cooperative/registry/1100.MarketplaceOfferTemplate/index.ts
+++ b/components/cooptypes/src/cooperative/registry/1100.MarketplaceOfferTemplate/index.ts
@@ -1,0 +1,95 @@
+import type { IGenerate, IMetaDocument } from '../../document'
+import type { ICooperativeData, IVars } from '../../model'
+
+export const registry_id = 1100
+
+// Модель действия для генерации
+export interface Action extends IGenerate {
+  registry_id: number
+}
+
+export type Meta = IMetaDocument & Action
+
+// Модель данных документа — шаблон публичной оферты ЦПП «Стол заказов» для утверждения Советом.
+// Утверждается Советом (Story 1.9), нивелируется при регистрации пайщика (Story 1.11)
+// либо предъявляется L3 fallback gate на столе (Story 1.4).
+export interface Model {
+  meta: IMetaDocument
+  coop: ICooperativeData
+  vars: IVars
+}
+
+export const title = 'Пользовательское соглашение (оферта) по присоединению к ЦПП «СТОЛ ЗАКАЗОВ»'
+export const description = 'Шаблон публичной оферты по ЦПП «СТОЛ ЗАКАЗОВ» для утверждения Советом'
+
+// Placeholder context: финальная редакция оферты ЦПП «Стол заказов» готовится
+// юридическим отделом (см. todo-tspp-templates.md). Структура повторяет
+// 999.BlagorostOfferTemplate, замена будет одной правкой `context` +
+// `translations` без изменения registry_id и подписей пайщиков.
+export const context = `<div class="digital-document"><div style="text-align: center"><h1 class="header">{% trans 'OFFER_TITLE' %}</h1><p class="subheader">{% trans 'offer_template_subtitle' %}</p></div><p class="placeholder-notice"><em>{% trans 'placeholder_notice' %}</em></p><p>{% trans 'offer_template_intro_1' %} {{coop.chairman.last_name}} {{coop.chairman.first_name}} {{coop.chairman.middle_name}}{% trans 'offer_template_intro_2' %}</p><p>{% trans 'offer_template_legal_basis' %} {{ vars.marketplace_program.protocol_number }} {% trans 'from' %} {{ vars.marketplace_program.protocol_day_month_year }}{% trans 'offer_template_legal_basis_2' %}</p><p>{% trans 'offer_template_acceptance' %} {{vars.website}} {% trans 'offer_template_acceptance_2' %}</p><div style="text-align: center"><h3>{% trans 'terms_title' %}</h3></div><p><strong>1.1.</strong> {% trans 'platform_term_definition' %}</p><p><strong>1.2.</strong> {% trans 'order_term_definition' %}</p><p><strong>1.3.</strong> {% trans 'supply_term_definition' %}</p><p><strong>1.4.</strong> {% trans 'participant_term_definition' %}</p><p><strong>1.5.</strong> {% trans 'site_term_definition' %}</p><div style="text-align: center"><h3>{% trans 'goals_title' %}</h3></div><p><strong>2.1.</strong> {% trans 'goals_intro_template' %}</p><div style="text-align: center"><h3>{% trans 'order_mechanism_title' %}</h3></div><p><strong>3.1.</strong> {% trans 'order_mechanism_intro_template' %}</p><div style="text-align: center"><h3>{% trans 'return_mechanism_title' %}</h3></div><p><strong>4.1.</strong> {% trans 'return_mechanism_intro_template' %}</p><div style="text-align: center"><h3>{% trans 'rights_obligations_title' %}</h3></div><p><strong>5.1.</strong> {% trans 'rights_obligations_intro_template' %}</p><div class="signature"><p style="margin-top: 40px;"><strong>{% trans 'agreement_signature_template' %}</strong></p></div></div><style>.digital-document {padding: 20px;white-space: pre-wrap;}.placeholder-notice {background: #fff3cd; padding: 10px; border-radius: 4px;}.subheader {padding-bottom: 20px;}.signature {padding-top: 20px;}</style>`
+
+export const translations = {
+  ru: {
+    OFFER_TITLE: 'ПОЛЬЗОВАТЕЛЬСКОЕ СОГЛАШЕНИЕ (ОФЕРТА) № ______',
+    offer_template_subtitle:
+      'по присоединению пайщиков Потребительского Кооператива "ВОСХОД" к целевой потребительской программе "СТОЛ ЗАКАЗОВ"',
+    placeholder_notice:
+      'РЫБА ДОКУМЕНТА. Финальная редакция оферты ЦПП «Стол заказов» готовится; до момента её утверждения этот документ занимает registry_id=1100 в платформенном реестре документов и используется как структурный заполнитель Story 1.7.',
+    offer_template_intro_1: 'Потребительский Кооператив «ВОСХОД» (далее «Общество») в лице Председателя Совета ',
+    offer_template_intro_2:
+      ', действующего на основании Устава с одной стороны, и Участник целевой потребительской программы "СТОЛ ЗАКАЗОВ" __________________________, действующий на основании собственного волеизъявления, с другой стороны, а вместе Стороны, согласились с нижеследующим:',
+    offer_template_legal_basis:
+      'Настоящее Пользовательское соглашение, составленное в соответствии с Гражданским кодексом РФ, Уставом Общества и на основании Положения Общества о целевой потребительской программе "СТОЛ ЗАКАЗОВ", утвержденном Собранием Совета Общества (Протокол №',
+    from: 'от',
+    offer_template_legal_basis_2:
+      '), формулируют соглашение между Обществом и Пайщиком, а также является по отношению к Пайщику Офертой от Общества, где Общество является Оферентом, а Пайщик является Акцептантом.',
+    offer_template_acceptance:
+      'Отметка о Согласии __________________________ с Настоящим Пользовательским соглашением производится электронно, а дата создания Личного кабинета пайщика на сайте',
+    offer_template_acceptance_2:
+      'считается акцептом __________________________ настоящей Оферты как пайщика Общества по взаимодействию между Пайщиком и Обществом в соответствии с условиями целевой потребительской программы "СТОЛ ЗАКАЗОВ" (далее "ЦПП").',
+    terms_title: '1. Термины и определения [рыба]',
+    platform_term_definition:
+      '«Платформа» — информационная экосистема Цифрового кооператива, в которой реализована хозяйственная деятельность Общества в рамках ЦПП.',
+    order_term_definition:
+      '«Заказ» — потребительский паевой взнос Участника в рамках ЦПП с целью получения товара, поставленного другим Участником-поставщиком в режиме кооперативного некоммерческого обмена.',
+    supply_term_definition:
+      '«Поставка» — внесение Участником-поставщиком имущественного паевого взноса в виде товаров для дальнейшего распределения между Участниками-заказчиками.',
+    participant_term_definition:
+      '«Участник ЦПП (Участник) — пайщик», подтвердивший намерение участвовать в хозяйственной деятельности Общества фактом акцепта настоящего Пользовательского Соглашения.',
+    site_term_definition:
+      '«Сайт» — официальный сайт Общества, на котором опубликованы информация о ЦПП, текст настоящих общих условий и Положения о ЦПП, а также ЛК Участников.',
+    goals_title: '2. Цели и задачи [рыба]',
+    goals_intro_template:
+      'Целями ЦПП являются удовлетворение потребностей Участников в товарах для личного потребления и развитие некоммерческого обмена внутри Платформы.',
+    order_mechanism_title: '3. Хозяйственный механизм заказа и поставки [рыба]',
+    order_mechanism_intro_template:
+      'Участник-заказчик направляет потребительский паевой взнос; Участник-поставщик принимает заказ и поставляет товар. Расчёты и поставки идут через Цифровой кошелёк Платформы.',
+    return_mechanism_title: '4. Возврат и гарантийный возврат [рыба]',
+    return_mechanism_intro_template:
+      'Право требования возврата паевого взноса возникает при невыполнении поставки или ненадлежащем качестве товара в порядке, установленном настоящим Соглашением.',
+    rights_obligations_title: '5. Права и обязанности Сторон [рыба]',
+    rights_obligations_intro_template:
+      'Подробный перечень прав и обязанностей Участника и Общества будет уточнён в финальной редакции.',
+    agreement_signature_template:
+      '"СОГЛАСЕН"   _____________________________ (ФИО) ____________________ (Подпись) ___________________ (Дата)',
+  },
+}
+
+export const exampleData = {
+  coop: {
+    chairman: {
+      last_name: 'Муравьев',
+      first_name: 'Алексей',
+      middle_name: 'Николаевич',
+    },
+  },
+  vars: {
+    name: 'ВОСХОД',
+    short_abbr: 'ПК',
+    website: 'цифровой-кооператив.рф',
+    marketplace_program: {
+      protocol_number: '01-05-2026',
+      protocol_day_month_year: '01 мая 2026 г.',
+    },
+  },
+}

--- a/components/cooptypes/src/cooperative/registry/1101.MarketplaceOffer/index.ts
+++ b/components/cooptypes/src/cooperative/registry/1101.MarketplaceOffer/index.ts
@@ -1,0 +1,111 @@
+import type { IGenerate, IMetaDocument } from '../../document'
+import type { ICommonUser, ICooperativeData, IVars } from '../../model'
+
+export const registry_id = 1101
+
+// Модель действия для генерации
+export interface Action extends IGenerate {
+  registry_id: number
+}
+
+export type Meta = IMetaDocument & Action
+
+// Инстанс оферты ЦПП «Стол заказов» для конкретного пайщика
+// (renderуется из шаблона 1100.MarketplaceOfferTemplate). Создаётся:
+//  • при регистрации пайщика (Story 1.11, L2 онбординг);
+//  • при подписании через L3 fallback gate на столе (Story 1.4 после
+//    активации mutation подписания).
+export interface Model {
+  meta: IMetaDocument
+  coop: ICooperativeData
+  vars: IVars
+  common_user: ICommonUser
+  marketplace_agreement_number: string
+  marketplace_agreement_created_at: string
+}
+
+export const title = 'Пользовательское соглашение (оферта) по присоединению к ЦПП «СТОЛ ЗАКАЗОВ»'
+export const description = 'Публичная оферта по ЦПП «СТОЛ ЗАКАЗОВ» для пайщика с утвержденным шаблоном'
+
+// Placeholder context: финальная редакция готовится юристом (см.
+// 1100.MarketplaceOfferTemplate). Здесь воспроизводится та же структура
+// с подстановкой персональных данных пайщика.
+export const context = `<div class="digital-document"><div style="text-align: right; margin-bottom: 20px;"><p style="margin: 0px !important">{% trans 'APPROVED' %}</p><p style="margin: 0px !important">{% trans 'protocol' %} {{ vars.marketplace_offer_template.protocol_number }}</p><p style="margin: 0px !important">{{vars.full_abbr_genitive}} «{{vars.name}}»</p><p style="margin: 0px !important">{% trans 'from' %} {{ vars.marketplace_offer_template.protocol_day_month_year }}</p></div><div style="text-align: center"><h1 class="header">{% trans 'OFFER_TITLE', marketplace_agreement_number %}</h1><p class="subheader">{% trans 'offer_subtitle' %}</p></div><p class="placeholder-notice"><em>{% trans 'placeholder_notice' %}</em></p><p>{% trans 'offer_intro_1' %} {{coop.chairman.last_name}} {{coop.chairman.first_name}} {{coop.chairman.middle_name}}{% trans 'offer_intro_2' %} {{common_user.full_name_or_short_name}}{% trans 'offer_intro_3' %}</p><p>{% trans 'offer_legal_basis' %} {{ vars.marketplace_program.protocol_number }} {% trans 'from' %} {{ vars.marketplace_program.protocol_day_month_year }}{% trans 'offer_legal_basis_2' %}</p><p>{% trans 'offer_acceptance' %} {{common_user.full_name_or_short_name}} {% trans 'offer_acceptance_2' %} {{vars.website}} {% trans 'offer_acceptance_3' %} {{common_user.full_name_or_short_name}} {% trans 'offer_acceptance_4' %}</p><div style="text-align: center"><h3>{% trans 'terms_title' %}</h3></div><p><strong>1.1.</strong> {% trans 'platform_term_definition' %}</p><p><strong>1.2.</strong> {% trans 'order_term_definition' %}</p><p><strong>1.3.</strong> {% trans 'supply_term_definition' %}</p><p><strong>1.4.</strong> {% trans 'participant_term_definition' %}</p><p><strong>1.5.</strong> {% trans 'site_term_definition' %}</p><div style="text-align: center"><h3>{% trans 'goals_title' %}</h3></div><p><strong>2.1.</strong> {% trans 'goals_intro' %}</p><div style="text-align: center"><h3>{% trans 'order_mechanism_title' %}</h3></div><p><strong>3.1.</strong> {% trans 'order_mechanism_intro' %}</p><div style="text-align: center"><h3>{% trans 'return_mechanism_title' %}</h3></div><p><strong>4.1.</strong> {% trans 'return_mechanism_intro' %}</p><div style="text-align: center"><h3>{% trans 'rights_obligations_title' %}</h3></div><p><strong>5.1.</strong> {% trans 'rights_obligations_intro' %}</p><div class="signature"><p style="margin-top: 40px;"><strong>{% trans 'agreement_signature' %} {{common_user.full_name_or_short_name}}</strong></p><p>{{marketplace_agreement_created_at}}</p><p>{% trans 'signed_electronically' %}</p></div></div><style>.digital-document {padding: 20px;white-space: pre-wrap;}.placeholder-notice {background: #fff3cd; padding: 10px; border-radius: 4px;}.subheader {padding-bottom: 20px;}.signature {padding-top: 20px;}</style>`
+
+export const translations = {
+  ru: {
+    APPROVED: 'УТВЕРЖДЕНО:',
+    protocol: 'Протоколом Совета №',
+    from: 'от',
+    OFFER_TITLE: 'ПОЛЬЗОВАТЕЛЬСКОЕ СОГЛАШЕНИЕ (ОФЕРТА) № {0}',
+    offer_subtitle:
+      'по присоединению пайщиков Потребительского Кооператива "ВОСХОД" к целевой потребительской программе "СТОЛ ЗАКАЗОВ"',
+    placeholder_notice:
+      'РЫБА ДОКУМЕНТА. Финальная редакция оферты ЦПП «Стол заказов» готовится юридическим отделом; до её утверждения instance занимает registry_id=1101 в платформенном реестре документов и используется как структурный заполнитель.',
+    offer_intro_1: 'Потребительский Кооператив «ВОСХОД» (далее «Общество») в лице Председателя Совета ',
+    offer_intro_2: ', действующего на основании Устава с одной стороны, и Участник целевой потребительской программы "СТОЛ ЗАКАЗОВ" ',
+    offer_intro_3: ', действующий на основании собственного волеизъявления, с другой стороны, а вместе Стороны, согласились с нижеследующим:',
+    offer_legal_basis:
+      'Настоящее Пользовательское соглашение, составленное в соответствии с Гражданским кодексом РФ, Уставом Общества и на основании Положения Общества о целевой потребительской программе "СТОЛ ЗАКАЗОВ", утвержденном Собранием Совета Общества (Протокол №',
+    offer_legal_basis_2:
+      '), формулируют соглашение между Обществом и Пайщиком, а также является по отношению к Пайщику Офертой от Общества, где Общество является Оферентом, а Пайщик является Акцептантом.',
+    offer_acceptance: 'Отметка о Согласии',
+    offer_acceptance_2: 'с Настоящим Пользовательским соглашением производится электронно, а дата создания Личного кабинета пайщика на сайте',
+    offer_acceptance_3: 'считается акцептом',
+    offer_acceptance_4:
+      'настоящей Оферты как пайщика Общества по взаимодействию между Пайщиком и Обществом в соответствии с условиями целевой потребительской программы "СТОЛ ЗАКАЗОВ".',
+    terms_title: '1. Термины и определения [рыба]',
+    platform_term_definition:
+      '«Платформа» — информационная экосистема Цифрового кооператива, в которой реализована хозяйственная деятельность Общества в рамках ЦПП.',
+    order_term_definition:
+      '«Заказ» — потребительский паевой взнос Участника в рамках ЦПП с целью получения товара, поставленного другим Участником-поставщиком в режиме кооперативного некоммерческого обмена.',
+    supply_term_definition:
+      '«Поставка» — внесение Участником-поставщиком имущественного паевого взноса в виде товаров для дальнейшего распределения между Участниками-заказчиками.',
+    participant_term_definition:
+      '«Участник ЦПП (Участник) — пайщик», подтвердивший намерение участвовать в хозяйственной деятельности Общества фактом акцепта настоящего Пользовательского Соглашения.',
+    site_term_definition:
+      '«Сайт» — официальный сайт Общества, на котором опубликованы информация о ЦПП, текст настоящих общих условий и Положения о ЦПП, а также ЛК Участников.',
+    goals_title: '2. Цели и задачи [рыба]',
+    goals_intro:
+      'Целями ЦПП являются удовлетворение потребностей Участников в товарах для личного потребления и развитие некоммерческого обмена внутри Платформы.',
+    order_mechanism_title: '3. Хозяйственный механизм заказа и поставки [рыба]',
+    order_mechanism_intro:
+      'Участник-заказчик направляет потребительский паевой взнос; Участник-поставщик принимает заказ и поставляет товар. Расчёты и поставки идут через Цифровой кошелёк Платформы.',
+    return_mechanism_title: '4. Возврат и гарантийный возврат [рыба]',
+    return_mechanism_intro:
+      'Право требования возврата паевого взноса возникает при невыполнении поставки или ненадлежащем качестве товара в порядке, установленном настоящим Соглашением.',
+    rights_obligations_title: '5. Права и обязанности Сторон [рыба]',
+    rights_obligations_intro:
+      'Подробный перечень прав и обязанностей Участника и Общества будет уточнён в финальной редакции.',
+    agreement_signature: '"СОГЛАСЕН"',
+    signed_electronically: 'Подписано электронной подписью',
+  },
+}
+
+export const exampleData = {
+  coop: {
+    chairman: {
+      last_name: 'Муравьев',
+      first_name: 'Алексей',
+      middle_name: 'Николаевич',
+    },
+  },
+  vars: {
+    full_abbr_genitive: 'Потребительского Кооператива',
+    name: 'ВОСХОД',
+    website: 'цифровой-кооператив.рф',
+    marketplace_program: {
+      protocol_number: '01-05-2026',
+      protocol_day_month_year: '01 мая 2026 г.',
+    },
+    marketplace_offer_template: {
+      protocol_number: '15-05-2026',
+      protocol_day_month_year: '15 мая 2026 г.',
+    },
+  },
+  common_user: {
+    full_name_or_short_name: 'Иванов Иван Иванович',
+  },
+  marketplace_agreement_number: '12345',
+  marketplace_agreement_created_at: '14.05.2026',
+}

--- a/components/cooptypes/src/cooperative/registry/index.ts
+++ b/components/cooptypes/src/cooperative/registry/index.ts
@@ -67,6 +67,10 @@ export * as GenerationToCapitalizationConvertStatement from './1082.GenerationTo
 
 export * as CapitalizationToMainWalletConvertStatement from './1090.CapitalizationToMainWalletConvertStatement'
 
+// Marketplace — ЦПП «Стол заказов» (Story 1.7)
+export * as MarketplaceOfferTemplate from './1100.MarketplaceOfferTemplate'
+export * as MarketplaceOffer from './1101.MarketplaceOffer'
+
 export * as SosediAgreement from './699.SosediAgreement'
 
 // общие собрания


### PR DESCRIPTION
## Summary

Story 1.9 (Эпик 1 «Стол заказов» MVP). L1-онбординг: backend фиксирует state «положение ЦПП принято Советом».

- **`extension.config.coopAcceptance`** = `{accepted, document_registry_id, accepted_at, accepted_by_board_decision_id}`.
- **Bootstrap migration v2** добавляет поле к существующим v1 конфигам идемпотентно.
- **`MarketplaceCoopAcceptanceService`**: `getStatus()`, `accept(input)` через `EXTENSION_REPOSITORY`.
- **GraphQL**:
  - `Query marketplaceCppStatus` — открыт всем активным пайщикам (фронт решает, показывать ли баннер «Не подключено»).
  - `Mutation marketplaceAcceptCpp(input)` — admin-only через `@RequireMarketplaceAccess('Extension', 'configure')`.

**MVP-stub**: реальная интеграция с повесткой Совета (FR40, Эпик 8) ещё не готова — председатель передаёт `accepted_by_board_decision_id` как string без валидации. Phase 2 после Эпика 8: mutation добавит валидацию или переедет в core-controlled side-effect.

## Test plan

- [x] `tsc --noEmit` — 0 ошибок.
- [x] `jest -i tests/unit/marketplace` — 66/66 зелёных (6 acceptance + остальные).
- [ ] Manual: `mutation { marketplaceAcceptCpp(input: { document_registry_id: 1101, accepted_by_board_decision_id: "stub-1" }) { status document_registry_id accepted_at } }` под JWT председателя → `active`. Под JWT обычного пайщика → 403.

## Related

- Spec: `_bmad-output/implementation-artifacts/spec-1-9-marketplace-coop-acceptance.md`.
- Эпик 1 / Story 1.9 (FR43 L1; AR25, AR33, L9).
- Зависит: Story 1.8 (#377 base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)