### PR TITLE
fix(capital): подтянуть GenerationConvertStatement → MoneyInvestStatement

### DIFF
--- a/components/controller/src/application/document/documents-dto/generation-convert-statement-document.dto.ts
+++ b/components/controller/src/application/document/documents-dto/generation-convert-statement-document.dto.ts
@@ -9,7 +9,7 @@ import { SignedDigitalDocumentInputDTO } from '~/application/document/dto/signed
 type ExcludeCommonProps<T> = Omit<T, 'coopname' | 'username' | 'registry_id' | 'appendix_hash'>;
 
 // интерфейс параметров для генерации
-type action = Cooperative.Registry.GenerationConvertStatement.Action;
+type action = Cooperative.Registry.GenerationMoneyInvestStatement.Action;
 
 @InputType(`BaseGenerationConvertStatementMetaDocumentInput`)
 class BaseGenerationConvertStatementMetaDocumentInputDTO implements ExcludeCommonProps<action> {

--- a/components/controller/src/extensions/capital/application/services/distribution-management.service.ts
+++ b/components/controller/src/extensions/capital/application/services/distribution-management.service.ts
@@ -53,7 +53,7 @@ export class DistributionManagementService {
     const document = await this.documentInteractor.generateDocument({
       data: {
         ...enrichedData,
-        registry_id: Cooperative.Registry.GenerationConvertStatement.registry_id,
+        registry_id: Cooperative.Registry.GenerationMoneyInvestStatement.registry_id,
       },
       options,
     });

--- a/components/controller/src/extensions/capital/application/use-cases/distribution-management.interactor.ts
+++ b/components/controller/src/extensions/capital/application/use-cases/distribution-management.interactor.ts
@@ -45,7 +45,7 @@ export class DistributionManagementInteractor {
   async prepareGenerationConvertStatementData(
     data: GenerationConvertStatementGenerateDocumentInputDTO,
     currentUser: MonoAccountDomainInterface
-  ): Promise<Cooperative.Registry.GenerationConvertStatement.Action> {
+  ): Promise<Cooperative.Registry.GenerationMoneyInvestStatement.Action> {
     const projectHash = data.project_hash;
     if (!projectHash) {
       throw new Error('project_hash обязателен для генерации заявления о конвертации');
@@ -63,6 +63,6 @@ export class DistributionManagementInteractor {
     return {
       ...data,
       appendix_hash: userAppendix.appendix_hash,
-    } as Cooperative.Registry.GenerationConvertStatement.Action;
+    } as Cooperative.Registry.GenerationMoneyInvestStatement.Action;
   }
 }


### PR DESCRIPTION
## Что чинит

После merge PR #392 (унификация шаблона 1080) тип `Cooperative.Registry.GenerationConvertStatement` был переименован в `GenerationMoneyInvestStatement` в `@coopenomics/document`. В controller'е осталось 3 несинхронизированные ссылки, coopback падал на ts-node compile:

```
TS2551 / TS2724: Property 'GenerationConvertStatement' does not exist on type 'typeof index$3'. Did you mean 'GenerationMoneyInvestStatement'?
```

## Файлы

- `controller/.../distribution-management.service.ts:56` — `registry_id` в generation
- `controller/.../distribution-management.interactor.ts:48,66` — тип Action в return и as-cast
- `controller/.../generation-convert-statement-document.dto.ts:12` — type action в DTO

Без фикса coopback не стартует — блокировка всего dev-stack (зафиксировано после reboot dev-chain 2026-05-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)