### PR TITLE
fix(capital): revert ошибочной замены типов GenerationConvertStatement в #394

### DIFF
--- a/components/controller/src/application/document/documents-dto/generation-convert-statement-document.dto.ts
+++ b/components/controller/src/application/document/documents-dto/generation-convert-statement-document.dto.ts
@@ -9,7 +9,7 @@ import { SignedDigitalDocumentInputDTO } from '~/application/document/dto/signed
 type ExcludeCommonProps<T> = Omit<T, 'coopname' | 'username' | 'registry_id' | 'appendix_hash'>;
 
 // интерфейс параметров для генерации
-type action = Cooperative.Registry.GenerationMoneyInvestStatement.Action;
+type action = Cooperative.Registry.GenerationConvertStatement.Action;
 
 @InputType(`BaseGenerationConvertStatementMetaDocumentInput`)
 class BaseGenerationConvertStatementMetaDocumentInputDTO implements ExcludeCommonProps<action> {

--- a/components/controller/src/extensions/capital/application/services/distribution-management.service.ts
+++ b/components/controller/src/extensions/capital/application/services/distribution-management.service.ts
@@ -53,7 +53,7 @@ export class DistributionManagementService {
     const document = await this.documentInteractor.generateDocument({
       data: {
         ...enrichedData,
-        registry_id: Cooperative.Registry.GenerationMoneyInvestStatement.registry_id,
+        registry_id: Cooperative.Registry.GenerationConvertStatement.registry_id,
       },
       options,
     });

--- a/components/controller/src/extensions/capital/application/use-cases/distribution-management.interactor.ts
+++ b/components/controller/src/extensions/capital/application/use-cases/distribution-management.interactor.ts
@@ -45,7 +45,7 @@ export class DistributionManagementInteractor {
   async prepareGenerationConvertStatementData(
     data: GenerationConvertStatementGenerateDocumentInputDTO,
     currentUser: MonoAccountDomainInterface
-  ): Promise<Cooperative.Registry.GenerationMoneyInvestStatement.Action> {
+  ): Promise<Cooperative.Registry.GenerationConvertStatement.Action> {
     const projectHash = data.project_hash;
     if (!projectHash) {
       throw new Error('project_hash обязателен для генерации заявления о конвертации');
@@ -63,6 +63,6 @@ export class DistributionManagementInteractor {
     return {
       ...data,
       appendix_hash: userAppendix.appendix_hash,
-    } as Cooperative.Registry.GenerationMoneyInvestStatement.Action;
+    } as Cooperative.Registry.GenerationConvertStatement.Action;
   }
 }


### PR DESCRIPTION
## Что чинит

Откатывает PR #394, который заменил тип `Cooperative.Registry.GenerationConvertStatement` (1080) на `GenerationMoneyInvestStatement` (1020) в 3 файлах controller'а. Это разные шаблоны с разными полями:

| Шаблон | Назначение | Ключевые поля Action |
|---|---|---|
| **1080 GenerationConvertStatement** | Заявление о трансляции паевого взноса (моё PR #392) | `project_hash`, `main_wallet_amount`, `blagorost_wallet_amount`, `to_wallet`, `to_blagorost`, `appendix_hash` |
| **1020 GenerationMoneyInvestStatement** | Заявление о денежном паевом взносе (программа Генерация) | совсем другой набор |

## Почему #394 был ошибочным

DTO `BaseGenerationConvertStatementMetaDocumentInputDTO` декларирует поля 1080, но через `implements ExcludeCommonProps<action>` сейчас завязан на тип 1020. На `as`-cast в interactor TypeScript выдаёт **TS2352** — Action'ы 1020 и 1080 не пересекаются достаточно по полям.

Текущий код фактически compile-passing только за счёт того, что `as Cooperative.Registry.GenerationMoneyInvestStatement.Action` подавляет несоответствие. Семантически он передаёт объект с полями 1080 под видом 1020, и фабрика на бекенде получает данные с не теми ключами.

## Откуда вообще взялась ошибка coopback после #392

Скорее всего на dev-узле остался несвежий dist `@coopenomics/cooptypes` со старым именем `GenerationToMainWalletConvertStatement`. Лечится пересборкой пакета (`pnpm -w build` или `cd components/cooptypes && unbuild`), не переименованием ссылок.

## Файлы

- `controller/.../generation-convert-statement-document.dto.ts:12`
- `controller/.../distribution-management.service.ts:56`
- `controller/.../distribution-management.interactor.ts:48,66`

## Проверка

- `pnpm run typecheck` в `cooptypes`, `factory`, `sdk`, `controller` — все чистые

## Test plan

- [ ] Пересобрать `@coopenomics/cooptypes` на dev-узле перед запуском coopback
- [ ] Проверить старт coopback (`ts-node compile`)
- [ ] E2E: «Получить долю в ОАП» → генерация документа 1080 → `appendix_hash` подтягивается → on-chain `convertsegm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)