### PR TITLE
fix(capital/convertsegm): регистрировать 1080 в реестре документов как completed

### DIFF
--- a/components/contracts/cpp/capital/app/result_submission/push_result/convertsegm.cpp
+++ b/components/contracts/cpp/capital/app/result_submission/push_result/convertsegm.cpp
@@ -34,6 +34,10 @@ void capital::convertsegm(eosio::name coopname, eosio::name username,
                           document2 convert_statement) {
   require_auth(coopname);
 
+  // Проверяем подпись заявления о трансляции паевого взноса (шаблон 1080).
+  // Без этого on-chain принял бы любую сконструированную document2 без валидной подписи.
+  verify_document_or_fail(convert_statement, {username});
+
   // Получаем сегмент пайщика
   auto segment = Capital::Segments::get_segment_or_fail(coopname, project_hash, username,
                                                       "Сегмент пайщика не найден");
@@ -107,6 +111,20 @@ void capital::convertsegm(eosio::name coopname, eosio::name username,
 
   // Инкрементируем счётчик сконвертированных сегментов
   Capital::Projects::increment_converted_segments(coopname, current_project.id);
+
+  // Регистрируем заявление о трансляции (1080) в реестре документов и сразу
+  // помечаем процесс p.cap.rid завершённым: package = result_hash — анкер процесса.
+  // make_complete_document шлёт newsubmitted + newresolved одной парой, off-chain
+  // controller видит документ в registry со статусом completed.
+  // Делаем ДО delete_result, чтобы линковка прошла, пока result_hash ещё анкер.
+  Soviet::make_complete_document(
+    _capital,
+    coopname,
+    username,
+    Names::Capital::CONVERT_SEGMENT,
+    result_hash,
+    convert_statement
+  );
 
   // Удаляем сегмент после конвертации
   Capital::Segments::remove_segment(coopname, segment.id);

--- a/components/contracts/cpp/lib/core/names.hpp
+++ b/components/contracts/cpp/lib/core/names.hpp
@@ -124,5 +124,6 @@ namespace Names {
     constexpr eosio::name CREATE_WITHDRAW_2 = "createwthd2"_n; // акцепт возврата из проекта
     constexpr eosio::name CREATE_WITHDRAW_3 = "createwthd3"_n; // акцепт возврата из программы
     constexpr eosio::name CREATE_RESULT = "createresult"_n; // акцепт результата
+    constexpr eosio::name CONVERT_SEGMENT = "convertsegm"_n; // финальная фаза p.cap.rid — трансляция паевого взноса
   }
 }


### PR DESCRIPTION
## Что чинит

В `convertsegm` (финальная фаза процесса `p.cap.rid`) принимался `document2 convert_statement` (шаблон 1080), но:

1. **Подпись не проверялась** — отсутствовал `verify_document_or_fail`. On-chain принял бы любую сконструированную `document2` без валидной подписи пайщика. У соседних фаз (`signact1`, `signact2`) verify есть — здесь забыли.
2. **Документ не попадал в реестр** — не было `newlink`/`newsubmitted`/`newresolved`. Off-chain controller (process_instance) не видел финальный документ привязанным к `result_hash`, процесс `p.cap.rid` не помечался completed. Заявление о трансляции просто «терялось».

## Канон

- `soviet/src/system/converttoaxn.cpp:54`
- `soviet/src/agreement/sndagreement.cpp:104`

Оба используют `Soviet::make_complete_document(calling_contract, coopname, username, action, package_hash, document)` — inline отправляет `newsubmitted` + `newresolved` подряд, off-chain controller видит документ в registry со статусом completed, привязанным к `package` (анкер процесса).

## Изменено

- `lib/core/names.hpp` — новая константа `Names::Capital::CONVERT_SEGMENT = ""convertsegm""_n` (12 символов, валидная EOSIO name)
- `capital/app/result_submission/push_result/convertsegm.cpp`:
  - `verify_document_or_fail(convert_statement, {username})` сразу после `require_auth`
  - `Soviet::make_complete_document(_capital, coopname, username, Names::Capital::CONVERT_SEGMENT, result_hash, convert_statement)` **до** `Capital::Results::delete_result` — чтобы линковка прошла, пока `result_hash` ещё анкер процесса

## Проверка

- ✅ `bash build.sh capital test` через `dicoop/blockchain:latest` — wasm собран без ошибок (warnings — старые ricardian, не относящиеся к фиксу)

## Test plan

- [ ] Редеплой `capital.wasm` на dev-chain (`testnet.coopenomics.world`) через `setup-contracts.yaml`
- [ ] E2E: «Получить долю в ОАП» → 1080 генерируется → подписывается → `convertsegm` → проверить:
  - запись в реестре документов с привязкой `package = result_hash`
  - статус процесса `p.cap.rid` = completed (controller выкатывает `process_instance.completed_at`)
- [ ] Регресс: «битая» подпись → action должен упасть с ошибкой verify_document (раньше проходил)

## Зависимости

Не зависит от PR #396 — там фикс controller (TS-ссылки), здесь фикс контракта capital (on-chain). Деплоится отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)