### PR TITLE
fix(asset-formatting): truncate (toward-zero) до 2 знаков вместо math-round

### DIFF
--- a/components/desktop/extensions/reports/pages/WalletsPage/ui/ParticipantWalletsPage.vue
+++ b/components/desktop/extensions/reports/pages/WalletsPage/ui/ParticipantWalletsPage.vue
@@ -209,7 +209,7 @@ const WalletCell = {
           { class: ['cell-line', valueClass, props.bold ? 'bold' : ''].join(' ') },
           [
             h(QIcon, { name: icon, size: '12px', class: 'cell-icon' }),
-            h('span', { class: 'cell-value' }, formatAsset2Digits(`${amount.toFixed(4)} RUB`)),
+            h('span', { class: 'cell-value' }, formatAsset2Digits(`${amount} RUB`)),
             h(QTooltip, { anchor: 'top middle', self: 'bottom middle', delay: 200 }, () => tooltip),
           ],
         )

--- a/components/desktop/src/shared/lib/utils/addAssets.ts
+++ b/components/desktop/src/shared/lib/utils/addAssets.ts
@@ -1,8 +1,14 @@
+import { floorDecimalString } from './floorDecimalString';
+
 /**
- * Суммирует два актива (IAsset) с одинаковой валютой
- * @param asset1 - первый актив (например "100.00 RUB")
- * @param asset2 - второй актив (например "50.00 RUB")
- * @returns сумма активов в формате IAsset (например "150.00 RUB")
+ * Суммирует два актива (IAsset) с одинаковой валютой и возвращает
+ * результат с 2 знаками после запятой, обрезанный вниз (toward-zero),
+ * чтобы согласоваться с `formatAsset2Digits`: пользователь никогда
+ * не видит сумму больше реальной.
+ *
+ * @param asset1 - первый актив (например "100.0000 RUB")
+ * @param asset2 - второй актив (например "50.0000 RUB")
+ * @returns сумма активов с 2 знаками (например "150.00 RUB")
  */
 export const addAssets = (asset1: string, asset2: string): string => {
   if (!asset1 || asset1 === '0') return asset2 || '0.00';
@@ -33,8 +39,9 @@ export const addAssets = (asset1: string, asset2: string): string => {
   const sum = value1 + value2;
   const currencySymbol = parsed1.currency || parsed2.currency;
 
-  // Форматируем результат как строку без пробелов для совместимости с formatAsset2Digits
-  const formattedNumber = sum.toFixed(2);
+  // Truncate вниз через строку (с запасом точности до 10 знаков, чтобы FP-шум
+  // не округлил 0.29 как 0.28). Никогда не показываем сумму больше реальной.
+  const formattedNumber = floorDecimalString(sum.toFixed(10), 2);
 
   return currencySymbol
     ? `${formattedNumber} ${currencySymbol}`

--- a/components/desktop/src/shared/lib/utils/floorDecimalString.ts
+++ b/components/desktop/src/shared/lib/utils/floorDecimalString.ts
@@ -1,0 +1,24 @@
+/**
+ * Truncate (toward-zero) числовой строки до displayPrecision знаков
+ * после запятой — на уровне строки, без преобразования в Number, чтобы
+ * избежать FP-погрешности (например, 0.29 * 100 = 28.999999999999996 в IEEE 754).
+ *
+ * Принцип: «никогда не показать пользователю сумму больше, чем реально
+ * есть на кошельке». 99999.9999 → "99999.99" (а не "100000.00", как
+ * сделал бы math-round). Применяется как для отображения asset
+ * (precision=4 → display=2), так и для подготовки input при отправке
+ * в контракт (не превысить ввод пользователя/доступный баланс).
+ *
+ * @param numericString — десятичная строка без валюты, e.g. "99999.9999" или "-12.5"
+ * @param displayPrecision — сколько знаков оставить (по умолчанию 2)
+ */
+export const floorDecimalString = (numericString: string, displayPrecision = 2): string => {
+  const trimmed = numericString.trim();
+  const negative = trimmed.startsWith('-');
+  const abs = negative ? trimmed.slice(1) : trimmed;
+  const [intPartRaw, decPartRaw = ''] = abs.split('.');
+  const intPart = intPartRaw || '0';
+  const decPart = decPartRaw.padEnd(displayPrecision, '0').slice(0, displayPrecision);
+  const result = displayPrecision > 0 ? `${intPart}.${decPart}` : intPart;
+  return negative ? `-${result}` : result;
+};

--- a/components/desktop/src/shared/lib/utils/formatAsset2Digits.ts
+++ b/components/desktop/src/shared/lib/utils/formatAsset2Digits.ts
@@ -1,26 +1,36 @@
+import { floorDecimalString } from './floorDecimalString';
+
 /**
- * Форматирует актив с двумя знаками после запятой и извлекает символ валюты
- * @param value - строка с активом (например "1000000 EOS")
- * @returns отформатированная строка (например "100.00 EOS")
+ * Форматирует актив для отображения: truncate (toward-zero) до 2 знаков
+ * после запятой + локальная группировка разрядов (ru-RU).
+ *
+ * Truncate, а не math-round: 99999.9999 → "99 999,99" (не "100 000,00").
+ * Никогда не показываем пользователю сумму больше, чем реально доступна
+ * на кошельке — иначе попытка инвестировать «весь баланс» упирается
+ * в `walletop TRANSFER: insufficient funds` из-за расхождения precision=4
+ * на цепи и precision=2 в UI.
+ *
+ * @param value — строка с активом (например "99999.9999 RUB")
+ * @returns отформатированная строка (например "99 999,99 RUB")
  */
 export const formatAsset2Digits = (value: string): string => {
   if (!value || value === '0') return '0.00';
 
-  // Разделяем значение по пробелу для извлечения символа валюты
   const parts = value.trim().split(' ');
   const cleanValue = parts[0] || value;
   const currencySymbol = parts[1] || '';
-
-  // Убираем символ валюты и форматируем как число
   const numericValue = cleanValue.replace(/[^\d.-]/g, '');
-  const numValue = parseFloat(numericValue);
 
-  if (isNaN(numValue)) return '0.00';
+  if (!numericValue || numericValue === '-' || isNaN(parseFloat(numericValue))) {
+    return '0.00';
+  }
 
-  const formattedNumber = new Intl.NumberFormat('ru-RU', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(numValue);
+  const truncated = floorDecimalString(numericValue, 2);
+  const negative = truncated.startsWith('-');
+  const abs = negative ? truncated.slice(1) : truncated;
+  const [intStr, decStr] = abs.split('.');
+  const intGrouped = new Intl.NumberFormat('ru-RU').format(BigInt(intStr));
+  const formattedNumber = `${negative ? '-' : ''}${intGrouped},${decStr}`;
 
   return currencySymbol
     ? `${formattedNumber} ${currencySymbol}`

--- a/components/desktop/src/shared/lib/utils/formatToAsset.ts
+++ b/components/desktop/src/shared/lib/utils/formatToAsset.ts
@@ -1,4 +1,17 @@
-export function formatToAsset(amount: string | number, currency: string, precision=4): string {
-  const formattedAmount = (typeof amount === 'number' ? amount : parseFloat(amount)).toFixed(precision);
+import { floorDecimalString } from './floorDecimalString';
+
+/**
+ * Конвертирует число/строку в asset-строку с заданной precision (по умолчанию 4)
+ * для отправки в контракт.
+ *
+ * Использует truncate (toward-zero), не math-round: чтобы пользователь не
+ * мог случайно превысить свой ввод или доступный баланс. Например, ввод
+ * 99.99999 RUB при precision=4 даёт "99.9999 RUB" (не "100.0000").
+ */
+export function formatToAsset(amount: string | number, currency: string, precision = 4): string {
+  const num = typeof amount === 'number' ? amount : parseFloat(amount);
+  if (isNaN(num)) return `0.${'0'.repeat(precision)} ${currency}`;
+  const padded = num.toFixed(precision + 4);
+  const formattedAmount = floorDecimalString(padded, precision);
   return `${formattedAmount} ${currency}`;
 }

--- a/components/desktop/src/shared/lib/utils/index.ts
+++ b/components/desktop/src/shared/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './formatDateForEos';
+export * from './floorDecimalString';
 export * from './formatToAsset';
 export * from './formatAsset2Digits';
 export * from './addAssets';

--- a/components/factory/src/Factory/index.ts
+++ b/components/factory/src/Factory/index.ts
@@ -675,11 +675,27 @@ export abstract class DocFactory<T extends IGenerate> {
     }
   }
 
+  /**
+   * Truncate (toward-zero) числовой строки до displayPrecision знаков
+   * на уровне строки — без FP-погрешности (0.29 * 100 = 28.999... в IEEE 754).
+   * Принцип: «никогда не показать в документе сумму больше реальной».
+   */
+  private truncateDecimal(numericStr: string, displayPrecision: number): string {
+    const negative = numericStr.startsWith('-')
+    const abs = negative ? numericStr.slice(1) : numericStr
+    const [intPartRaw, decPartRaw = ''] = abs.split('.')
+    const intPart = intPartRaw || '0'
+    const decPart = decPartRaw.padEnd(displayPrecision, '0').slice(0, displayPrecision)
+    const result = displayPrecision > 0 ? `${intPart}.${decPart}` : intPart
+    return negative ? `-${result}` : result
+  }
+
   public formatShare(value: string | number, precision: number = 2): string {
-    const parsed = typeof value === 'string' ? Number.parseFloat(value) : value
+    const str = typeof value === 'string' ? value : value.toString()
+    const parsed = Number.parseFloat(str)
     if (Number.isNaN(parsed))
       return typeof value === 'string' ? value : value.toString()
-    return parsed.toFixed(precision)
+    return this.truncateDecimal(parsed.toFixed(precision + 4), precision)
   }
 
   public formatAsset(asset: string, precision: number = 2): string {
@@ -689,7 +705,7 @@ export abstract class DocFactory<T extends IGenerate> {
     if (!match)
       return asset
     const [, amount, symbol] = match
-    return `${Number.parseFloat(amount).toFixed(precision)} ${symbol}`
+    return `${this.truncateDecimal(amount, precision)} ${symbol}`
   }
 
   public formatPaymentDetails(paymentMethod: any, recipientName: string): string {


### PR DESCRIPTION
## Контекст

В сценарии «инвестировал 100k → выполнил задачу → convertsegm вернул в ЦК» reward-per-share формулы в `capital` оставляют «пыль» (классическая потеря младшего знака при делении пула на shares). Реальный баланс на `w.wal.share/<user>` оказывается, например, `99999.9999 RUB`, а UI/документы показывают `100 000,00` из-за math-round в форматтере. Пользователь жмёт «инвестировать 100 000» → `walletop TRANSFER` падает с `insufficient funds`.

Фикс на стороне отображения — никогда не показывать сумму больше реальной.

## Принцип

**Truncate (toward-zero)** до displayPrecision знаков **на уровне строки**, без `Number`-конверсии — чтобы FP-погрешность (`0.29 * 100 = 28.999...`) не съела копейку у безобидных значений.

- `99999.9999` → `99 999,99` (раньше: `100 000,00`)
- `100000.0000` → `100 000,00` (без изменений)
- `0.29` → `0,29` (FP-trap избегается)
- `1.2399` → `1,23` (truncate, не round-up)

## Изменения

**desktop**
- `src/shared/lib/utils/floorDecimalString.ts` — новая единая утилита (источник истины).
- `src/shared/lib/utils/formatAsset2Digits.ts` — truncate + Intl-группировка через BigInt.
- `src/shared/lib/utils/formatToAsset.ts` — число → asset (precision=4) с floor-вниз: ввод `99.99999` → `99.9999 RUB` (не `100.0000`).
- `src/shared/lib/utils/addAssets.ts` — итог суммирования truncate-вниз.
- `extensions/reports/pages/WalletsPage/ui/ParticipantWalletsPage.vue:212` — убран double-formatting (`${amount.toFixed(4)} RUB` → `${amount} RUB`).

**factory**
- `src/Factory/index.ts` — приватный `truncateDecimal()`; через него `formatAsset()` и `formatShare()`. 12 шаблонов документов (заявления, акты) теперь показывают сумму, не превышающую реальную.

## Не затронуто (фолоу-ап)

- **10 файлов с inline `.toFixed(4)`** перед отправкой в контракт (`features/User/AddUser`, `features/Union/AddCooperative`, `WalletTransferDialog.vue:234` и др.). Принцип тот же — заменить inline на `formatToAsset()`. Отдельный PR, чтобы не раздувать blast этого.
- **Backend (`coopback`)** — собственного форматирования сумм нет, asset-строки проходят сквозь.

## Test plan

- [x] Runtime-проверка `formatAsset2Digits`: `99999.9999`, `100000.0000`, `0.29`, `0.10`, `1.2345`, `1.2399`, `1234567.8901`, `0`, `""` — все ок.
- [x] Runtime-проверка `formatToAsset` precision=4: `99.99999`, `100`, `0.29`, `"99999.9999"` — все ок.
- [x] `vue-tsc` по desktop — exit 0 (ошибки только про отсутствие `.quasar/tsconfig.json` в worktree, не код).
- [x] `tsc --noEmit` по factory — `Factory/index.ts` чистый (существующие ошибки в template-файлах 1080/1081/1082 не от этого PR, см. stale `cooptypes`).
- [ ] **Mаnual**: открыть страницу кошельков на десктопе с пайщиком, у которого баланс `99999.9999 RUB` — должно отображаться `99 999,99 RUB`, кнопка «инвестировать всё» должна формировать `99999.9999` и проходить on-chain.
- [ ] **Manual**: документ «Заявление о трансляции паевого взноса» (registry_id=1080) — суммы в шаблоне должны соответствовать реально перенесённым.

После merge: пересобрать `factory` (`pnpm -F @coopenomics/factory build`), чтобы dist подхватился потребителями.

🤖 Generated with [Claude Code](https://claude.com/claude-code)