### PR TITLE
Эпик 11 (тех.долги): FR45 AC5 jest-тесты + 598-21 frontend batch-flow

### DIFF
--- a/components/controller/schema.gql
+++ b/components/controller/schema.gql
@@ -7926,6 +7926,46 @@ type MarketplaceLabelInventoryResult {
   inventory: [MarketplaceInventoryItem!]!
 }
 
+input MarketplaceLabelShipmentInventoryInput {
+  """Стратегия маркировки по умолчанию для всех заказов партии."""
+  default_strategy: MarketplaceBarcodeStrategy
+
+  """Формат штрих-кода для всей партии. По умолчанию — CODE128."""
+  format: MarketplaceBarcodeFormat
+
+  """
+  Перекрытия стратегии для отдельных заказов партии (если состав смешанный).
+  """
+  per_order_overrides: [MarketplaceLabelShipmentInventoryOverride!]
+
+  """Партия поставки, для всех заказов которой формируются этикетки."""
+  shipment_id: ID!
+}
+
+input MarketplaceLabelShipmentInventoryOverride {
+  """Заказ в составе партии, для которого задаётся отдельная стратегия."""
+  order_id: ID!
+
+  """Размер упаковки для стратегии PER_PACKAGE именно для этого заказа."""
+  pack_size: Int
+
+  """Стратегия маркировки именно для этого заказа партии."""
+  strategy: MarketplaceBarcodeStrategy
+}
+
+type MarketplaceLabelShipmentInventoryResult {
+  """Сгенерированные наклейки по всем промаркированным заказам партии."""
+  inventory: [MarketplaceInventoryItem!]!
+
+  """Идентификаторы заказов, которые были промаркированы этим вызовом."""
+  labeled_order_ids: [ID!]!
+
+  """
+  Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность).
+  """
+  skipped_order_ids: [ID!]!
+}
+
 input MarketplaceListAplReceptionsByBranameInput {
   """Идентификатор КУ-получателя."""
   braname: String!
@@ -10641,6 +10681,11 @@ type Mutation {
   Оператор КУ маркирует имущество заказа внутренним штрих-кодом (Code128 или EAN-13).
   """
   marketplaceLabelInventory(data: MarketplaceLabelInventoryInput!): MarketplaceLabelInventoryResult!
+
+  """
+  Массовая маркировка имущества всех заказов одной партии поставки за один вызов. Идемпотентно: уже промаркированные заказы пропускаются.
+  """
+  marketplaceLabelShipmentInventory(data: MarketplaceLabelShipmentInventoryInput!): MarketplaceLabelShipmentInventoryResult!
 
   """
   Председатель кооперативного участка открывает выдачу первой подписью акта — заказ готов к получению пайщиком.

--- a/components/controller/src/extensions/marketplace/application/services/marketplace-apl-reception.service.spec.ts
+++ b/components/controller/src/extensions/marketplace/application/services/marketplace-apl-reception.service.spec.ts
@@ -1,0 +1,357 @@
+import { ConflictException } from '@nestjs/common';
+import { MarketplaceAplReceptionService } from './marketplace-apl-reception.service';
+import { MarketplaceAplReceptionDomainEntity } from '../../domain/entities/marketplace-apl-reception.entity';
+import {
+  MarketplaceAplReceptionStatuses,
+  MarketplaceAplReceptionVariants,
+} from '../../domain/entities/marketplace-apl-reception.types';
+import type { MarketplaceOrderDomainEntity } from '../../domain/entities/marketplace-order.entity';
+import type { MarketplaceShipmentDomainRepository } from '../../domain/repositories/marketplace-shipment.repository';
+import type { MarketplaceOrderDomainRepository } from '../../domain/repositories/marketplace-order.repository';
+import type { MarketplaceAplReceptionDomainRepository } from '../../domain/repositories/marketplace-apl-reception.repository';
+import type { MarketplaceOutgoingPaymentRequestDomainRepository } from '../../domain/repositories/marketplace-outgoing-payment-request.repository';
+import type { MarketplaceOfferCountersService } from './marketplace-offer-counters.service';
+import type { MarketplaceCanonicalBlockchainPort } from '../../domain/ports/marketplace-canonical-blockchain.port';
+import type { GatewayInteractorPort } from '~/domain/wallet/ports/gateway-interactor.port';
+import type { DocumentDomainService } from '~/domain/document/services/document-domain.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+function buildOrder(overrides: Partial<MarketplaceOrderDomainEntity> = {}): MarketplaceOrderDomainEntity {
+  return {
+    id: 'order-1',
+    coopname: 'voskhod',
+    orderer_account: 'pai1',
+    offer_id: 'offer-1',
+    cycle_id: 'cycle-1',
+    delivery_braname: 'ku.krasn.1',
+    order_hash: '0xorder1hash',
+    quantity: 2,
+    price_per_unit: '150.0000',
+    total_cost: '300.0000',
+    status: 'BLOCKED',
+    ...overrides,
+  } as unknown as MarketplaceOrderDomainEntity;
+}
+
+function buildReception(
+  overrides: Partial<MarketplaceAplReceptionDomainEntity> = {}
+): MarketplaceAplReceptionDomainEntity {
+  const reception = new MarketplaceAplReceptionDomainEntity({
+    id: 'apl-1',
+    coopname: 'voskhod',
+    shipment_id: 'ship-1',
+    cycle_id: 'cycle-1',
+    braname: 'ku.krasn.1',
+    offerer_account: 'supplier1',
+    variant: MarketplaceAplReceptionVariants.IN_PERSON,
+    status: MarketplaceAplReceptionStatuses.PENDING_SUPPLIER_SIGN,
+    fact_quantity_per_order: [{ order_id: 'order-1', fact_quantity: 2 }],
+    ttn_number: null,
+    expeditor_data: null,
+    created_by_operator_account: 'operator1',
+    supplier_signed_at: null,
+    supplier_signsupp_tx_hash: null,
+    chairman_signed_at: null,
+    chairman_account: null,
+    chairman_signchair_tx_hash: null,
+    total_amount: '300.0000',
+    created_at: new Date('2026-05-19T00:00:00Z'),
+    updated_at: new Date('2026-05-19T00:00:00Z'),
+  });
+  for (const k of Object.keys(overrides)) {
+    (reception as any)[k] = (overrides as any)[k];
+  }
+  return reception;
+}
+
+function buildMocks() {
+  const shipmentRepo = {
+    findById: jest.fn(),
+    applyStatusTransition: jest.fn(),
+  } as unknown as jest.Mocked<MarketplaceShipmentDomainRepository>;
+
+  const orderRepo = {
+    findByCycleId: jest.fn(),
+    applyStatusTransition: jest.fn(),
+  } as unknown as jest.Mocked<MarketplaceOrderDomainRepository>;
+
+  const receptionRepo = {
+    findById: jest.fn(),
+    findByShipmentId: jest.fn(),
+    create: jest.fn(),
+    applySignatures: jest.fn(),
+  } as unknown as jest.Mocked<MarketplaceAplReceptionDomainRepository>;
+
+  const counters = {
+    onOrderBlocked: jest.fn(),
+    onOrderConsumed: jest.fn(),
+    onOrderRolledBack: jest.fn(),
+  } as unknown as jest.Mocked<MarketplaceOfferCountersService>;
+
+  const chainPort = {
+    signSupp: jest.fn(),
+    signChair: jest.fn(),
+    payOut: jest.fn(),
+  } as unknown as jest.Mocked<MarketplaceCanonicalBlockchainPort>;
+
+  const paymentRepo = {
+    findByOrderId: jest.fn(),
+    createPending: jest.fn(),
+  } as unknown as jest.Mocked<MarketplaceOutgoingPaymentRequestDomainRepository>;
+
+  const coreGateway = {
+    createSystemOutgoingPayment: jest.fn(),
+    setPaymentStatus: jest.fn(),
+  } as unknown as jest.Mocked<GatewayInteractorPort>;
+
+  const documentDomainService = {
+    generateDocument: jest.fn(),
+  } as unknown as jest.Mocked<DocumentDomainService>;
+
+  const logger = {
+    setContext: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  } as any;
+
+  return {
+    shipmentRepo,
+    orderRepo,
+    receptionRepo,
+    counters,
+    chainPort,
+    paymentRepo,
+    coreGateway,
+    documentDomainService,
+    logger,
+  };
+}
+
+function buildService(mocks: ReturnType<typeof buildMocks>): MarketplaceAplReceptionService {
+  const service = new MarketplaceAplReceptionService(
+    mocks.shipmentRepo,
+    mocks.orderRepo,
+    mocks.receptionRepo,
+    mocks.counters,
+    mocks.chainPort,
+    mocks.paymentRepo,
+    { symbol: 'RUB', decimals: 4 },
+    mocks.coreGateway,
+    mocks.documentDomainService,
+    new EventEmitter2(),
+    mocks.logger
+  );
+  // Подпись клиента в jest-spec'е не верифицируем: цель тестов — поведение
+  // compensating-rollback после chainPort.* throws, а не PublicKey.verify.
+  jest.spyOn(service as any, 'verifyDocumentSignature').mockImplementation(() => undefined);
+  return service;
+}
+
+function buildSignedDocs(orderIds: string[]): any[] {
+  return orderIds.map((orderId) => ({
+    meta: { order_id: orderId },
+    signatures: [{ public_key: 'EOSpub', signature: 'SIGstub', signed_hash: 'hash' }],
+    toDocument: () => ({ stub_act: true, order_id: orderId }),
+  }));
+}
+
+describe('MarketplaceAplReceptionService — FR45 AC5 compensating-rollback', () => {
+  let mocks: ReturnType<typeof buildMocks>;
+  let service: MarketplaceAplReceptionService;
+
+  beforeEach(() => {
+    mocks = buildMocks();
+    service = buildService(mocks);
+  });
+
+  describe('signAsSupplier: chainPort.signSupp throws', () => {
+    it('бросает ConflictException и НЕ дергает receptionRepo.applySignatures', async () => {
+      const reception = buildReception();
+      const order = buildOrder({ id: 'order-1', order_hash: '0xorder1hash' });
+
+      mocks.receptionRepo.findById.mockResolvedValue(reception);
+      mocks.orderRepo.findByCycleId.mockResolvedValue([order]);
+      (mocks.chainPort.signSupp as jest.Mock).mockRejectedValue(new Error('chain RPC timeout'));
+
+      await expect(
+        service.signAsSupplier({
+          coopname: 'voskhod',
+          supplier_account: 'supplier1',
+          apl_reception_id: 'apl-1',
+          signed_documents: buildSignedDocs(['order-1']),
+        })
+      ).rejects.toThrow(ConflictException);
+
+      expect(mocks.chainPort.signSupp).toHaveBeenCalledTimes(1);
+      expect(mocks.receptionRepo.applySignatures).not.toHaveBeenCalled();
+      // Status объекта в памяти НЕ был перетёрт сервисом.
+      expect(reception.status).toBe(MarketplaceAplReceptionStatuses.PENDING_SUPPLIER_SIGN);
+    });
+
+    it('повторная подпись после failure идемпотентна: повторно отправляет signsupp и при успехе ставит PENDING_CHAIRMAN_RECEPTION_SIGN', async () => {
+      const reception = buildReception();
+      const order = buildOrder({ id: 'order-1' });
+
+      mocks.receptionRepo.findById.mockResolvedValue(reception);
+      mocks.orderRepo.findByCycleId.mockResolvedValue([order]);
+      (mocks.chainPort.signSupp as jest.Mock)
+        .mockRejectedValueOnce(new Error('chain RPC timeout'))
+        .mockResolvedValueOnce({ response: { transaction_id: 'tx-supplier-2' } });
+
+      mocks.receptionRepo.applySignatures.mockImplementation(async (_id, patch) => {
+        Object.assign(reception, patch);
+        return reception;
+      });
+
+      await expect(
+        service.signAsSupplier({
+          coopname: 'voskhod',
+          supplier_account: 'supplier1',
+          apl_reception_id: 'apl-1',
+          signed_documents: buildSignedDocs(['order-1']),
+        })
+      ).rejects.toThrow(ConflictException);
+
+      const result = await service.signAsSupplier({
+        coopname: 'voskhod',
+        supplier_account: 'supplier1',
+        apl_reception_id: 'apl-1',
+        signed_documents: buildSignedDocs(['order-1']),
+      });
+
+      expect(mocks.chainPort.signSupp).toHaveBeenCalledTimes(2);
+      expect(mocks.receptionRepo.applySignatures).toHaveBeenCalledTimes(1);
+      const patch = mocks.receptionRepo.applySignatures.mock.calls[0][1] as any;
+      expect(patch.status).toBe(MarketplaceAplReceptionStatuses.PENDING_CHAIRMAN_RECEPTION_SIGN);
+      expect(patch.supplier_signsupp_tx_hash).toBe('tx-supplier-2');
+      expect(result.apl_reception.status).toBe(MarketplaceAplReceptionStatuses.PENDING_CHAIRMAN_RECEPTION_SIGN);
+    });
+  });
+
+  describe('signAsChairman: chainPort.signChair throws', () => {
+    it('бросает ConflictException и НЕ дергает receptionRepo.applySignatures', async () => {
+      const reception = buildReception({
+        status: MarketplaceAplReceptionStatuses.PENDING_CHAIRMAN_RECEPTION_SIGN,
+        supplier_signed_at: new Date('2026-05-19T01:00:00Z'),
+        supplier_signsupp_tx_hash: 'tx-supplier-ok',
+      });
+      const order = buildOrder({ id: 'order-1', order_hash: '0xorder1hash' });
+
+      mocks.receptionRepo.findById.mockResolvedValue(reception);
+      mocks.orderRepo.findByCycleId.mockResolvedValue([order]);
+      (mocks.chainPort.signChair as jest.Mock).mockRejectedValue(new Error('chain insufficient_funds'));
+
+      await expect(
+        service.signAsChairman({
+          coopname: 'voskhod',
+          chairman_account: 'chair1',
+          apl_reception_id: 'apl-1',
+          signed_documents: buildSignedDocs(['order-1']),
+        })
+      ).rejects.toThrow(ConflictException);
+
+      expect(mocks.chainPort.signChair).toHaveBeenCalledTimes(1);
+      expect(mocks.receptionRepo.applySignatures).not.toHaveBeenCalled();
+      expect(mocks.orderRepo.applyStatusTransition).not.toHaveBeenCalled();
+      expect(mocks.shipmentRepo.applyStatusTransition).not.toHaveBeenCalled();
+      expect(reception.status).toBe(MarketplaceAplReceptionStatuses.PENDING_CHAIRMAN_RECEPTION_SIGN);
+    });
+
+    it('повторная подпись после failure идемпотентна: ставит ACCEPTED_TO_COOP, продвигает Order и Shipment', async () => {
+      const reception = buildReception({
+        status: MarketplaceAplReceptionStatuses.PENDING_CHAIRMAN_RECEPTION_SIGN,
+        supplier_signed_at: new Date('2026-05-19T01:00:00Z'),
+        supplier_signsupp_tx_hash: 'tx-supplier-ok',
+      });
+      const order = buildOrder({ id: 'order-1', delivery_braname: 'ku.krasn.1' });
+
+      mocks.receptionRepo.findById.mockResolvedValue(reception);
+      mocks.orderRepo.findByCycleId.mockResolvedValue([order]);
+      (mocks.chainPort.signChair as jest.Mock)
+        .mockRejectedValueOnce(new Error('chain insufficient_funds'))
+        .mockResolvedValueOnce({ response: { transaction_id: 'tx-chair-2' } });
+
+      mocks.receptionRepo.applySignatures.mockImplementation(async (_id, patch) => {
+        Object.assign(reception, patch);
+        return reception;
+      });
+
+      await expect(
+        service.signAsChairman({
+          coopname: 'voskhod',
+          chairman_account: 'chair1',
+          apl_reception_id: 'apl-1',
+          signed_documents: buildSignedDocs(['order-1']),
+        })
+      ).rejects.toThrow(ConflictException);
+
+      const result = await service.signAsChairman({
+        coopname: 'voskhod',
+        chairman_account: 'chair1',
+        apl_reception_id: 'apl-1',
+        signed_documents: buildSignedDocs(['order-1']),
+      });
+
+      expect(mocks.chainPort.signChair).toHaveBeenCalledTimes(2);
+      expect(mocks.receptionRepo.applySignatures).toHaveBeenCalledTimes(1);
+      const patch = mocks.receptionRepo.applySignatures.mock.calls[0][1] as any;
+      expect(patch.status).toBe(MarketplaceAplReceptionStatuses.ACCEPTED_TO_COOP);
+      expect(patch.chairman_account).toBe('chair1');
+      expect(patch.chairman_signchair_tx_hash).toBe('tx-chair-2');
+
+      expect(mocks.orderRepo.applyStatusTransition).toHaveBeenCalledWith(
+        'order-1',
+        'ACCEPTED_TO_COOP',
+        expect.any(String)
+      );
+      expect(mocks.shipmentRepo.applyStatusTransition).toHaveBeenCalledWith(
+        'ship-1',
+        'ACCEPTED_TO_COOP'
+      );
+      expect(result.apl_reception.status).toBe(MarketplaceAplReceptionStatuses.ACCEPTED_TO_COOP);
+    });
+  });
+
+  describe('гард: подпись в неверном статусе', () => {
+    it('signAsSupplier на не-PENDING_SUPPLIER_SIGN → ConflictException без обращения к chainPort', async () => {
+      const reception = buildReception({
+        status: MarketplaceAplReceptionStatuses.ACCEPTED_TO_COOP,
+      });
+      mocks.receptionRepo.findById.mockResolvedValue(reception);
+
+      await expect(
+        service.signAsSupplier({
+          coopname: 'voskhod',
+          supplier_account: 'supplier1',
+          apl_reception_id: 'apl-1',
+          signed_documents: buildSignedDocs(['order-1']),
+        })
+      ).rejects.toThrow(ConflictException);
+
+      expect(mocks.chainPort.signSupp).not.toHaveBeenCalled();
+      expect(mocks.receptionRepo.applySignatures).not.toHaveBeenCalled();
+    });
+
+    it('signAsChairman на не-PENDING_CHAIRMAN_RECEPTION_SIGN → ConflictException без обращения к chainPort', async () => {
+      const reception = buildReception({
+        status: MarketplaceAplReceptionStatuses.PENDING_SUPPLIER_SIGN,
+      });
+      mocks.receptionRepo.findById.mockResolvedValue(reception);
+
+      await expect(
+        service.signAsChairman({
+          coopname: 'voskhod',
+          chairman_account: 'chair1',
+          apl_reception_id: 'apl-1',
+          signed_documents: buildSignedDocs(['order-1']),
+        })
+      ).rejects.toThrow(ConflictException);
+
+      expect(mocks.chainPort.signChair).not.toHaveBeenCalled();
+      expect(mocks.receptionRepo.applySignatures).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/components/controller/zeus/const.ts
+++ b/components/controller/zeus/const.ts
@@ -725,6 +725,14 @@ export const AllTypesProps: Record<string,any> = {
 		format:"MarketplaceBarcodeFormat",
 		strategy:"MarketplaceBarcodeStrategy"
 	},
+	MarketplaceLabelShipmentInventoryInput:{
+		default_strategy:"MarketplaceBarcodeStrategy",
+		format:"MarketplaceBarcodeFormat",
+		per_order_overrides:"MarketplaceLabelShipmentInventoryOverride"
+	},
+	MarketplaceLabelShipmentInventoryOverride:{
+		strategy:"MarketplaceBarcodeStrategy"
+	},
 	MarketplaceListAplReceptionsByBranameInput:{
 
 	},
@@ -1356,6 +1364,9 @@ export const AllTypesProps: Record<string,any> = {
 		},
 		marketplaceLabelInventory:{
 			data:"MarketplaceLabelInventoryInput"
+		},
+		marketplaceLabelShipmentInventory:{
+			data:"MarketplaceLabelShipmentInventoryInput"
 		},
 		marketplaceOpenIssuance:{
 			data:"MarketplaceOpenIssuanceInput"
@@ -4045,6 +4056,11 @@ export const ReturnTypes: Record<string,any> = {
 	MarketplaceLabelInventoryResult:{
 		inventory:"MarketplaceInventoryItem"
 	},
+	MarketplaceLabelShipmentInventoryResult:{
+		inventory:"MarketplaceInventoryItem",
+		labeled_order_ids:"ID",
+		skipped_order_ids:"ID"
+	},
 	MarketplaceMemberWallet:{
 		coopname:"String",
 		username:"String",
@@ -4684,6 +4700,7 @@ export const ReturnTypes: Record<string,any> = {
 		marketplaceDetailKU:"MarketplaceKUDetails",
 		marketplaceFinalizeIssuance:"MarketplaceIssuanceResult",
 		marketplaceLabelInventory:"MarketplaceLabelInventoryResult",
+		marketplaceLabelShipmentInventory:"MarketplaceLabelShipmentInventoryResult",
 		marketplaceOpenIssuance:"MarketplaceIssuanceResult",
 		marketplaceRejectOffer:"MarketplaceOffer",
 		marketplaceRejectReturnAtVisit:"MarketplaceReturnClaimResult",

--- a/components/controller/zeus/index.ts
+++ b/components/controller/zeus/index.ts
@@ -6766,6 +6766,34 @@ export type ValueTypes = {
 		__typename?: boolean | `@${string}`,
 	['...on MarketplaceLabelInventoryResult']?: Omit<ValueTypes["MarketplaceLabelInventoryResult"], "...on MarketplaceLabelInventoryResult">
 }>;
+	["MarketplaceLabelShipmentInventoryInput"]: {
+	/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: ValueTypes["MarketplaceBarcodeStrategy"] | undefined | null | Variable<any, string>,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: ValueTypes["MarketplaceBarcodeFormat"] | undefined | null | Variable<any, string>,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<ValueTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null | Variable<any, string>,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: ValueTypes["ID"] | Variable<any, string>
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+	/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: ValueTypes["ID"] | Variable<any, string>,
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null | Variable<any, string>,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: ValueTypes["MarketplaceBarcodeStrategy"] | undefined | null | Variable<any, string>
+};
+	["MarketplaceLabelShipmentInventoryResult"]: AliasType<{
+	/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory?:ValueTypes["MarketplaceInventoryItem"],
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids?:boolean | `@${string}`,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids?:boolean | `@${string}`,
+		__typename?: boolean | `@${string}`,
+	['...on MarketplaceLabelShipmentInventoryResult']?: Omit<ValueTypes["MarketplaceLabelShipmentInventoryResult"], "...on MarketplaceLabelShipmentInventoryResult">
+}>;
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 	/** Идентификатор КУ-получателя. */
 	braname: string | Variable<any, string>
@@ -8118,6 +8146,7 @@ marketplaceDeclineOrderFromOpenPool?: [{	input: ValueTypes["MarketplaceDeclineOr
 marketplaceDetailKU?: [{	data: ValueTypes["MarketplaceDetailKUInput"] | Variable<any, string>},ValueTypes["MarketplaceKUDetails"]],
 marketplaceFinalizeIssuance?: [{	data: ValueTypes["MarketplaceFinalizeIssuanceInput"] | Variable<any, string>},ValueTypes["MarketplaceIssuanceResult"]],
 marketplaceLabelInventory?: [{	data: ValueTypes["MarketplaceLabelInventoryInput"] | Variable<any, string>},ValueTypes["MarketplaceLabelInventoryResult"]],
+marketplaceLabelShipmentInventory?: [{	data: ValueTypes["MarketplaceLabelShipmentInventoryInput"] | Variable<any, string>},ValueTypes["MarketplaceLabelShipmentInventoryResult"]],
 marketplaceOpenIssuance?: [{	data: ValueTypes["MarketplaceOpenIssuanceInput"] | Variable<any, string>},ValueTypes["MarketplaceIssuanceResult"]],
 marketplaceRejectOffer?: [{	input: ValueTypes["MarketplaceRejectOfferInput"] | Variable<any, string>},ValueTypes["MarketplaceOffer"]],
 marketplaceRejectReturnAtVisit?: [{	data: ValueTypes["MarketplaceRejectReturnAtVisitInput"] | Variable<any, string>},ValueTypes["MarketplaceReturnClaimResult"]],
@@ -16667,6 +16696,33 @@ export type ResolverInputTypes = {
 	inventory?:ResolverInputTypes["MarketplaceInventoryItem"],
 		__typename?: boolean | `@${string}`
 }>;
+	["MarketplaceLabelShipmentInventoryInput"]: {
+	/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: ResolverInputTypes["MarketplaceBarcodeStrategy"] | undefined | null,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: ResolverInputTypes["MarketplaceBarcodeFormat"] | undefined | null,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<ResolverInputTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: ResolverInputTypes["ID"]
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+	/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: ResolverInputTypes["ID"],
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: ResolverInputTypes["MarketplaceBarcodeStrategy"] | undefined | null
+};
+	["MarketplaceLabelShipmentInventoryResult"]: AliasType<{
+	/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory?:ResolverInputTypes["MarketplaceInventoryItem"],
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids?:boolean | `@${string}`,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids?:boolean | `@${string}`,
+		__typename?: boolean | `@${string}`
+}>;
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 	/** Идентификатор КУ-получателя. */
 	braname: string
@@ -17979,6 +18035,7 @@ marketplaceDeclineOrderFromOpenPool?: [{	input: ResolverInputTypes["MarketplaceD
 marketplaceDetailKU?: [{	data: ResolverInputTypes["MarketplaceDetailKUInput"]},ResolverInputTypes["MarketplaceKUDetails"]],
 marketplaceFinalizeIssuance?: [{	data: ResolverInputTypes["MarketplaceFinalizeIssuanceInput"]},ResolverInputTypes["MarketplaceIssuanceResult"]],
 marketplaceLabelInventory?: [{	data: ResolverInputTypes["MarketplaceLabelInventoryInput"]},ResolverInputTypes["MarketplaceLabelInventoryResult"]],
+marketplaceLabelShipmentInventory?: [{	data: ResolverInputTypes["MarketplaceLabelShipmentInventoryInput"]},ResolverInputTypes["MarketplaceLabelShipmentInventoryResult"]],
 marketplaceOpenIssuance?: [{	data: ResolverInputTypes["MarketplaceOpenIssuanceInput"]},ResolverInputTypes["MarketplaceIssuanceResult"]],
 marketplaceRejectOffer?: [{	input: ResolverInputTypes["MarketplaceRejectOfferInput"]},ResolverInputTypes["MarketplaceOffer"]],
 marketplaceRejectReturnAtVisit?: [{	data: ResolverInputTypes["MarketplaceRejectReturnAtVisitInput"]},ResolverInputTypes["MarketplaceReturnClaimResult"]],
@@ -26248,6 +26305,32 @@ export type ModelTypes = {
 		/** Сгенерированные наклейки: одна или несколько в зависимости от стратегии. */
 	inventory: Array<ModelTypes["MarketplaceInventoryItem"]>
 };
+	["MarketplaceLabelShipmentInventoryInput"]: {
+	/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: ModelTypes["MarketplaceBarcodeStrategy"] | undefined | null,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: ModelTypes["MarketplaceBarcodeFormat"] | undefined | null,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<ModelTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: ModelTypes["ID"]
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+	/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: ModelTypes["ID"],
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: ModelTypes["MarketplaceBarcodeStrategy"] | undefined | null
+};
+	["MarketplaceLabelShipmentInventoryResult"]: {
+		/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory: Array<ModelTypes["MarketplaceInventoryItem"]>,
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids: Array<ModelTypes["ID"]>,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids: Array<ModelTypes["ID"]>
+};
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 	/** Идентификатор КУ-получателя. */
 	braname: string
@@ -27931,6 +28014,8 @@ export type ModelTypes = {
 	marketplaceFinalizeIssuance: ModelTypes["MarketplaceIssuanceResult"],
 	/** Оператор КУ маркирует имущество заказа внутренним штрих-кодом (Code128 или EAN-13). */
 	marketplaceLabelInventory: ModelTypes["MarketplaceLabelInventoryResult"],
+	/** Массовая маркировка имущества всех заказов одной партии поставки за один вызов. Идемпотентно: уже промаркированные заказы пропускаются. */
+	marketplaceLabelShipmentInventory: ModelTypes["MarketplaceLabelShipmentInventoryResult"],
 	/** Председатель кооперативного участка открывает выдачу первой подписью акта — заказ готов к получению пайщиком. */
 	marketplaceOpenIssuance: ModelTypes["MarketplaceIssuanceResult"],
 	/** Отклонить Offer с причиной (status → REJECTED) (admin) */
@@ -36745,6 +36830,34 @@ export type GraphQLTypes = {
 	inventory: Array<GraphQLTypes["MarketplaceInventoryItem"]>,
 	['...on MarketplaceLabelInventoryResult']: Omit<GraphQLTypes["MarketplaceLabelInventoryResult"], "...on MarketplaceLabelInventoryResult">
 };
+	["MarketplaceLabelShipmentInventoryInput"]: {
+		/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: GraphQLTypes["MarketplaceBarcodeStrategy"] | undefined | null,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: GraphQLTypes["MarketplaceBarcodeFormat"] | undefined | null,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<GraphQLTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: GraphQLTypes["ID"]
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+		/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: GraphQLTypes["ID"],
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: GraphQLTypes["MarketplaceBarcodeStrategy"] | undefined | null
+};
+	["MarketplaceLabelShipmentInventoryResult"]: {
+	__typename: "MarketplaceLabelShipmentInventoryResult",
+	/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory: Array<GraphQLTypes["MarketplaceInventoryItem"]>,
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids: Array<GraphQLTypes["ID"]>,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids: Array<GraphQLTypes["ID"]>,
+	['...on MarketplaceLabelShipmentInventoryResult']: Omit<GraphQLTypes["MarketplaceLabelShipmentInventoryResult"], "...on MarketplaceLabelShipmentInventoryResult">
+};
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 		/** Идентификатор КУ-получателя. */
 	braname: string
@@ -38520,6 +38633,8 @@ export type GraphQLTypes = {
 	marketplaceFinalizeIssuance: GraphQLTypes["MarketplaceIssuanceResult"],
 	/** Оператор КУ маркирует имущество заказа внутренним штрих-кодом (Code128 или EAN-13). */
 	marketplaceLabelInventory: GraphQLTypes["MarketplaceLabelInventoryResult"],
+	/** Массовая маркировка имущества всех заказов одной партии поставки за один вызов. Идемпотентно: уже промаркированные заказы пропускаются. */
+	marketplaceLabelShipmentInventory: GraphQLTypes["MarketplaceLabelShipmentInventoryResult"],
 	/** Председатель кооперативного участка открывает выдачу первой подписью акта — заказ готов к получению пайщиком. */
 	marketplaceOpenIssuance: GraphQLTypes["MarketplaceIssuanceResult"],
 	/** Отклонить Offer с причиной (status → REJECTED) (admin) */
@@ -42722,6 +42837,8 @@ type ZEUS_VARIABLES = {
 	["MarketplaceIssueActSignedDocumentInput"]: ValueTypes["MarketplaceIssueActSignedDocumentInput"];
 	["MarketplaceIssueActSignedMetaDocumentInput"]: ValueTypes["MarketplaceIssueActSignedMetaDocumentInput"];
 	["MarketplaceLabelInventoryInput"]: ValueTypes["MarketplaceLabelInventoryInput"];
+	["MarketplaceLabelShipmentInventoryInput"]: ValueTypes["MarketplaceLabelShipmentInventoryInput"];
+	["MarketplaceLabelShipmentInventoryOverride"]: ValueTypes["MarketplaceLabelShipmentInventoryOverride"];
 	["MarketplaceListAplReceptionsByBranameInput"]: ValueTypes["MarketplaceListAplReceptionsByBranameInput"];
 	["MarketplaceListCatalogInput"]: ValueTypes["MarketplaceListCatalogInput"];
 	["MarketplaceListConsolidatedRequestsInput"]: ValueTypes["MarketplaceListConsolidatedRequestsInput"];

--- a/components/desktop/src/pages/Marketplace/OperatorInventoryLabeling/api/index.ts
+++ b/components/desktop/src/pages/Marketplace/OperatorInventoryLabeling/api/index.ts
@@ -1,5 +1,5 @@
-import { Mutations, Queries } from '@coopenomics/sdk';
-import { client } from 'src/shared/api/client';
+import { Mutations, Queries } from '@coopenomics/sdk'
+import { client } from 'src/shared/api/client'
 
 export interface MarketplaceOrderForLabeling {
   id: string;
@@ -24,23 +24,58 @@ export interface MarketplaceInventoryItemView {
   labeled_at: string;
 }
 
+export interface MarketplaceShipmentView {
+  id: string;
+  coopname: string;
+  cycle_id: string;
+  braname: string;
+  offerer_account: string;
+  delivery_variant: 'SELF_PICKUP' | 'EXPEDITOR' | string;
+  status: string;
+  total_amount: string;
+  ttn_number: string | null;
+  created_at: string;
+}
+
+export interface MarketplaceLabelShipmentInventoryResultView {
+  inventory: MarketplaceInventoryItemView[];
+  labeled_order_ids: string[];
+  skipped_order_ids: string[];
+}
+
 export async function fetchInventoryByBraname(braname: string): Promise<MarketplaceInventoryItemView[]> {
   const result = await client.Query(Queries.Marketplace.ListInventory.query, {
     variables: { data: { braname } },
-  });
-  return result[Queries.Marketplace.ListInventory.name] as unknown as MarketplaceInventoryItemView[];
+  })
+  return result[Queries.Marketplace.ListInventory.name] as unknown as MarketplaceInventoryItemView[]
 }
 
-export async function labelInventory(data: {
-  order_id: string;
-  strategy?: 'PER_ORDER' | 'PER_UNIT' | 'PER_PACKAGE';
-  format?: 'CODE128' | 'EAN13';
-  pack_size?: number;
-}): Promise<{ inventory: MarketplaceInventoryItemView[] }> {
+const SHIPMENT_STATUSES_FOR_LABELING = new Set(['SUPPLY_PREPARED', 'RECEPTION_IN_PROGRESS'])
+
+export async function fetchShipmentsForLabeling(braname?: string): Promise<MarketplaceShipmentView[]> {
+  const data: Queries.Marketplace.ListShipments.IInput['data'] = {}
+  if (braname) data.braname = braname
+  const result = await client.Query(Queries.Marketplace.ListShipments.query, {
+    variables: { data },
+  })
+  const shipments = result[Queries.Marketplace.ListShipments.name] as unknown as MarketplaceShipmentView[]
+  return shipments.filter((s) => SHIPMENT_STATUSES_FOR_LABELING.has(s.status))
+}
+
+export async function labelInventory(data: Mutations.Marketplace.LabelInventory.IInput['data']): Promise<{ inventory: MarketplaceInventoryItemView[] }> {
   const result = await client.Mutation(Mutations.Marketplace.LabelInventory.mutation, {
     variables: { data },
-  });
+  })
   return result[Mutations.Marketplace.LabelInventory.name] as unknown as {
     inventory: MarketplaceInventoryItemView[];
-  };
+  }
+}
+
+export async function labelShipmentInventory(
+  data: Mutations.Marketplace.LabelShipmentInventory.IInput['data'],
+): Promise<MarketplaceLabelShipmentInventoryResultView> {
+  const result = await client.Mutation(Mutations.Marketplace.LabelShipmentInventory.mutation, {
+    variables: { data },
+  })
+  return result[Mutations.Marketplace.LabelShipmentInventory.name] as unknown as MarketplaceLabelShipmentInventoryResultView
 }

--- a/components/desktop/src/pages/Marketplace/OperatorInventoryLabeling/ui/OperatorInventoryLabelingPage.vue
+++ b/components/desktop/src/pages/Marketplace/OperatorInventoryLabeling/ui/OperatorInventoryLabelingPage.vue
@@ -1,74 +1,137 @@
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue';
-import { Loading } from 'quasar';
-import { SuccessAlert, FailAlert } from 'src/shared/api';
-import { BarcodeDisplay } from 'src/widgets/Marketplace/BarcodeDisplay';
+import { computed, onMounted, ref } from 'vue'
+import { Loading } from 'quasar'
+import { SuccessAlert, FailAlert } from 'src/shared/api'
+import { BarcodeDisplay } from 'src/widgets/Marketplace/BarcodeDisplay'
 import {
   fetchInventoryByBraname,
+  fetchShipmentsForLabeling,
   labelInventory,
+  labelShipmentInventory,
   type MarketplaceInventoryItemView,
-} from '../api';
+  type MarketplaceShipmentView,
+} from '../api'
 
-/**
- * Story 5.5 + техдолг 598-21: операторский стол маркировки имущества.
- *
- * Левая колонка — ввод order_id и кнопка «Сгенерировать этикетки».
- * Правая колонка — batch-режим печати: все этикетки текущей партии
- * выводятся в одну сетку для печати на принтере 80×40 мм одним заданием.
- *
- * Стратегия маркировки читается из Offer по умолчанию (per-Offer
- * `barcode_strategy`, техдолг 598-22), кнопки переопределения остаются
- * как admin-override. Канон widget: `BarcodeDisplay` (UX-DR12).
- */
+type LabelingMode = 'PER_ORDER' | 'BATCH'
+type BarcodeStrategy = 'PER_ORDER' | 'PER_UNIT' | 'PER_PACKAGE'
+type BarcodeFormat = 'CODE128' | 'EAN13'
 
-const braname = ref<string>('');
-const orderIdInput = ref<string>('');
-const items = ref<MarketplaceInventoryItemView[]>([]);
-const loading = ref<boolean>(false);
+const braname = ref<string>('')
+const items = ref<MarketplaceInventoryItemView[]>([])
+const loading = ref<boolean>(false)
+
+const mode = ref<LabelingMode>('BATCH')
+
+const orderIdInput = ref<string>('')
+
+const shipments = ref<MarketplaceShipmentView[]>([])
+const selectedShipmentId = ref<string | null>(null)
+const defaultStrategy = ref<BarcodeStrategy | null>(null)
+const defaultFormat = ref<BarcodeFormat>('CODE128')
+const lastBatchSummary = ref<{ labeled: number; skipped: number } | null>(null)
+
+const strategyOptions = [
+  { label: 'По умолчанию из карточки товара', value: null },
+  { label: 'Одна этикетка на весь заказ', value: 'PER_ORDER' },
+  { label: 'Отдельная этикетка на каждую единицу', value: 'PER_UNIT' },
+  { label: 'Этикетка на упаковку', value: 'PER_PACKAGE' },
+] as const
+
+const formatOptions = [
+  { label: 'CODE128', value: 'CODE128' as const },
+  { label: 'EAN13', value: 'EAN13' as const },
+]
+
+const shipmentOptions = computed(() =>
+  shipments.value.map((s) => ({
+    label: `${s.id.slice(0, 8)} · ${s.braname} · ${s.delivery_variant} · ${s.status}`,
+    value: s.id,
+  })),
+)
 
 async function loadInventory(): Promise<void> {
-  if (!braname.value.trim()) return;
-  loading.value = true;
+  if (!braname.value.trim()) return
+  loading.value = true
   try {
-    items.value = await fetchInventoryByBraname(braname.value.trim());
+    items.value = await fetchInventoryByBraname(braname.value.trim())
   } catch (e) {
-    FailAlert(e, 'Не удалось загрузить инвентарь');
+    FailAlert(e, 'Не удалось загрузить инвентарь')
   } finally {
-    loading.value = false;
+    loading.value = false
   }
 }
 
-async function generateLabels(): Promise<void> {
-  if (!orderIdInput.value.trim()) {
-    FailAlert(new Error('Укажите идентификатор заказа.'));
-    return;
-  }
-  Loading.show({ message: 'Генерирую этикетки…' });
+async function loadShipments(): Promise<void> {
   try {
-    const result = await labelInventory({ order_id: orderIdInput.value.trim() });
-    SuccessAlert(`Сгенерировано ${result.inventory.length} этикеток — можно печатать`);
-    orderIdInput.value = '';
-    await loadInventory();
+    shipments.value = await fetchShipmentsForLabeling(braname.value.trim() || undefined)
   } catch (e) {
-    FailAlert(e, 'Не удалось сгенерировать этикетки');
+    FailAlert(e, 'Не удалось загрузить список партий')
+  }
+}
+
+async function generateLabelsPerOrder(): Promise<void> {
+  if (!orderIdInput.value.trim()) {
+    FailAlert(new Error('Укажите идентификатор заказа.'))
+    return
+  }
+  Loading.show({ message: 'Генерирую этикетки…' })
+  try {
+    const result = await labelInventory({ order_id: orderIdInput.value.trim() })
+    SuccessAlert(`Сгенерировано ${result.inventory.length} этикеток — можно печатать`)
+    orderIdInput.value = ''
+    await loadInventory()
+  } catch (e) {
+    FailAlert(e, 'Не удалось сгенерировать этикетки')
   } finally {
-    Loading.hide();
+    Loading.hide()
+  }
+}
+
+async function generateLabelsForShipment(): Promise<void> {
+  if (!selectedShipmentId.value) {
+    FailAlert(new Error('Выберите партию для маркировки.'))
+    return
+  }
+  Loading.show({ message: 'Маркирую партию…' })
+  try {
+    const result = await labelShipmentInventory({
+      shipment_id: selectedShipmentId.value,
+      default_strategy: defaultStrategy.value ?? undefined,
+      format: defaultFormat.value,
+    })
+    lastBatchSummary.value = {
+      labeled: result.labeled_order_ids.length,
+      skipped: result.skipped_order_ids.length,
+    }
+    const skipNote = result.skipped_order_ids.length
+      ? ` Пропущено уже промаркированных: ${result.skipped_order_ids.length}.`
+      : ''
+    SuccessAlert(
+      `Партия промаркирована. Заказов в работе: ${result.labeled_order_ids.length}.${skipNote} Готовы к печати ${result.inventory.length} этикеток.`,
+    )
+    if (!braname.value && result.inventory[0]?.braname) {
+      braname.value = result.inventory[0].braname
+    }
+    await loadInventory()
+  } catch (e) {
+    FailAlert(e, 'Не удалось промаркировать партию')
+  } finally {
+    Loading.hide()
   }
 }
 
 function openPrintWindow(): void {
-  window.print();
+  window.print()
 }
 
-onMounted(() => {
-  // В реальной интеграции braname придёт из current member / маршрута оператора.
-  // Здесь — пустой input до явного ввода.
-});
+onMounted(async () => {
+  await loadShipments()
+})
 </script>
 
 <template lang="pug">
 q-page.mp-role-operator.mp-inventory-labeling.q-pa-md
-  .row.q-mb-md.q-gutter-md.no-print
+  .row.q-mb-md.q-gutter-md.no-print.items-center
     q-input.col-3(
       v-model="braname"
       dense
@@ -77,22 +140,84 @@ q-page.mp-role-operator.mp-inventory-labeling.q-pa-md
       @keyup.enter="loadInventory"
     )
     q-btn(no-caps color="primary" :loading="loading" label="Загрузить инвентарь" @click="loadInventory")
+    q-btn(flat no-caps icon="refresh" label="Обновить список партий" @click="loadShipments")
     q-space
     q-btn(flat no-caps icon="print" label="Печать партии" :disable="!items.length" @click="openPrintWindow")
 
-  .row.q-gutter-md.q-mb-md.no-print
-    q-input.col-4(
-      v-model="orderIdInput"
-      dense
-      outlined
-      label="ID заказа для маркировки"
+  .row.q-mb-md.no-print
+    q-btn-toggle(
+      v-model="mode"
+      no-caps
+      unelevated
+      toggle-color="primary"
+      :options="[{ label: 'Маркировка партии целиком', value: 'BATCH' }, { label: 'Поштучно по заказу', value: 'PER_ORDER' }]"
     )
-    q-btn(no-caps unelevated color="primary" label="Сгенерировать этикетки" @click="generateLabels")
-    span.text-caption.text-grey-7.self-center
-      | Стратегия маркировки берётся из карточки товара поставщика (per-Offer).
+
+  q-card.q-mb-md.no-print(flat bordered v-if="mode === 'BATCH'")
+    q-card-section
+      .text-subtitle2.q-mb-sm Маркировка партии целиком
+      .text-caption.text-grey-7.q-mb-md
+        | Выберите партию поставки и стратегию по умолчанию. Сервер сам пройдёт по всем заказам партии и сгенерирует этикетки.
+        | Уже промаркированные заказы пропускаются автоматически.
+      .row.q-gutter-md.q-mb-sm
+        q-select.col-5(
+          v-model="selectedShipmentId"
+          dense
+          outlined
+          emit-value
+          map-options
+          label="Партия поставки"
+          :options="shipmentOptions"
+          :disable="!shipmentOptions.length"
+        )
+        q-select.col-3(
+          v-model="defaultStrategy"
+          dense
+          outlined
+          emit-value
+          map-options
+          label="Стратегия маркировки по умолчанию"
+          :options="strategyOptions"
+        )
+        q-select.col-3(
+          v-model="defaultFormat"
+          dense
+          outlined
+          emit-value
+          map-options
+          label="Формат штрих-кода"
+          :options="formatOptions"
+        )
+      .row.q-gutter-md.items-center
+        q-btn(
+          no-caps
+          unelevated
+          color="primary"
+          label="Промаркировать партию"
+          :disable="!selectedShipmentId"
+          @click="generateLabelsForShipment"
+        )
+        span.text-caption.text-grey-7(v-if="lastBatchSummary")
+          | Последний прогон: промаркировано {{ lastBatchSummary.labeled }}, пропущено {{ lastBatchSummary.skipped }}.
+        span.text-caption.text-grey-7(v-else)
+          | Стратегия по умолчанию переопределяет per-Offer настройку только если выбрана явно.
+
+  q-card.q-mb-md.no-print(flat bordered v-else)
+    q-card-section
+      .text-subtitle2.q-mb-sm Маркировка одного заказа
+      .row.q-gutter-md
+        q-input.col-4(
+          v-model="orderIdInput"
+          dense
+          outlined
+          label="ID заказа для маркировки"
+        )
+        q-btn(no-caps unelevated color="primary" label="Сгенерировать этикетки" @click="generateLabelsPerOrder")
+        span.text-caption.text-grey-7.self-center
+          | Стратегия маркировки берётся из карточки товара поставщика (per-Offer).
 
   .text-grey-7.text-center.q-pa-xl.no-print(v-if="!items.length")
-    | Инвентарь пуст. Загрузите КУ и нажмите «Сгенерировать этикетки» для нового заказа.
+    | Инвентарь пуст. Загрузите КУ, промаркируйте партию или отдельный заказ — этикетки появятся справа.
 
   .mp-inventory-labeling__grid(v-else)
     .mp-inventory-labeling__label(v-for="item in items" :key="item.id")
@@ -122,7 +247,16 @@ q-page.mp-role-operator.mp-inventory-labeling.q-pa-md
 @media print {
   .no-print { display: none !important; }
   .mp-inventory-labeling__grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4mm;
+  }
+  .mp-inventory-labeling__label {
+    page-break-inside: avoid;
+    width: 100%;
+  }
+  @page {
+    size: A4;
+    margin: 8mm;
   }
 }
 </style>

--- a/components/sdk/src/mutations/marketplace/index.ts
+++ b/components/sdk/src/mutations/marketplace/index.ts
@@ -14,6 +14,8 @@ export * as CreateOffer from './createOffer'
 export * as CreateShipment from './createShipment'
 /** Эпик 5: наклеить штрих-коды на единицы заказа (оператор КУ) */
 export * as LabelInventory from './labelInventory'
+/** Эпик 5: наклеить штрих-коды на все заказы партии разом (оператор КУ) */
+export * as LabelShipmentInventory from './labelShipmentInventory'
 /** Эпик 5: создать акт приёмки партии (оператор КУ) */
 export * as CreateAplReception from './createAplReception'
 /** Эпик 5: первая подпись поставщика на акте приёмки */

--- a/components/sdk/src/mutations/marketplace/labelShipmentInventory.ts
+++ b/components/sdk/src/mutations/marketplace/labelShipmentInventory.ts
@@ -1,0 +1,22 @@
+import { marketplaceLabelShipmentInventoryResultSelector } from '../../selectors/marketplace/inventorySelector'
+import { $, type GraphQLTypes, type InputType, type ModelTypes, Selector } from '../../zeus/index'
+
+export const name = 'marketplaceLabelShipmentInventory'
+
+export const mutation = Selector('Mutation')({
+  [name]: [
+    { data: $('data', 'MarketplaceLabelShipmentInventoryInput!') },
+    marketplaceLabelShipmentInventoryResultSelector,
+  ],
+})
+
+export interface IInput {
+  /**
+   * @private
+   */
+  [key: string]: unknown
+
+  data: ModelTypes['MarketplaceLabelShipmentInventoryInput']
+}
+
+export type IOutput = InputType<GraphQLTypes['Mutation'], typeof mutation>

--- a/components/sdk/src/selectors/marketplace/inventorySelector.ts
+++ b/components/sdk/src/selectors/marketplace/inventorySelector.ts
@@ -29,3 +29,11 @@ export const marketplaceInventoryItemSelector = Selector('MarketplaceInventoryIt
 export const marketplaceLabelInventoryResultSelector = Selector('MarketplaceLabelInventoryResult')({
   inventory: rawInventorySelector,
 })
+
+export const marketplaceLabelShipmentInventoryResultSelector = Selector(
+  'MarketplaceLabelShipmentInventoryResult',
+)({
+  inventory: rawInventorySelector,
+  labeled_order_ids: true,
+  skipped_order_ids: true,
+})

--- a/components/sdk/src/selectors/marketplace/inventorySelector.ts
+++ b/components/sdk/src/selectors/marketplace/inventorySelector.ts
@@ -30,10 +30,16 @@ export const marketplaceLabelInventoryResultSelector = Selector('MarketplaceLabe
   inventory: rawInventorySelector,
 })
 
-export const marketplaceLabelShipmentInventoryResultSelector = Selector(
-  'MarketplaceLabelShipmentInventoryResult',
-)({
+const rawLabelShipmentInventoryResultSelector = {
   inventory: rawInventorySelector,
   labeled_order_ids: true,
   skipped_order_ids: true,
-})
+}
+
+const _validateLabelShipmentInventoryResult: MakeAllFieldsRequired<
+  ValueTypes['MarketplaceLabelShipmentInventoryResult']
+> = rawLabelShipmentInventoryResultSelector
+
+export const marketplaceLabelShipmentInventoryResultSelector = Selector(
+  'MarketplaceLabelShipmentInventoryResult',
+)(rawLabelShipmentInventoryResultSelector)

--- a/components/sdk/src/zeus/const.ts
+++ b/components/sdk/src/zeus/const.ts
@@ -725,6 +725,14 @@ export const AllTypesProps: Record<string,any> = {
 		format:"MarketplaceBarcodeFormat",
 		strategy:"MarketplaceBarcodeStrategy"
 	},
+	MarketplaceLabelShipmentInventoryInput:{
+		default_strategy:"MarketplaceBarcodeStrategy",
+		format:"MarketplaceBarcodeFormat",
+		per_order_overrides:"MarketplaceLabelShipmentInventoryOverride"
+	},
+	MarketplaceLabelShipmentInventoryOverride:{
+		strategy:"MarketplaceBarcodeStrategy"
+	},
 	MarketplaceListAplReceptionsByBranameInput:{
 
 	},
@@ -1356,6 +1364,9 @@ export const AllTypesProps: Record<string,any> = {
 		},
 		marketplaceLabelInventory:{
 			data:"MarketplaceLabelInventoryInput"
+		},
+		marketplaceLabelShipmentInventory:{
+			data:"MarketplaceLabelShipmentInventoryInput"
 		},
 		marketplaceOpenIssuance:{
 			data:"MarketplaceOpenIssuanceInput"
@@ -4045,6 +4056,11 @@ export const ReturnTypes: Record<string,any> = {
 	MarketplaceLabelInventoryResult:{
 		inventory:"MarketplaceInventoryItem"
 	},
+	MarketplaceLabelShipmentInventoryResult:{
+		inventory:"MarketplaceInventoryItem",
+		labeled_order_ids:"ID",
+		skipped_order_ids:"ID"
+	},
 	MarketplaceMemberWallet:{
 		coopname:"String",
 		username:"String",
@@ -4684,6 +4700,7 @@ export const ReturnTypes: Record<string,any> = {
 		marketplaceDetailKU:"MarketplaceKUDetails",
 		marketplaceFinalizeIssuance:"MarketplaceIssuanceResult",
 		marketplaceLabelInventory:"MarketplaceLabelInventoryResult",
+		marketplaceLabelShipmentInventory:"MarketplaceLabelShipmentInventoryResult",
 		marketplaceOpenIssuance:"MarketplaceIssuanceResult",
 		marketplaceRejectOffer:"MarketplaceOffer",
 		marketplaceRejectReturnAtVisit:"MarketplaceReturnClaimResult",

--- a/components/sdk/src/zeus/index.ts
+++ b/components/sdk/src/zeus/index.ts
@@ -6766,6 +6766,34 @@ export type ValueTypes = {
 		__typename?: boolean | `@${string}`,
 	['...on MarketplaceLabelInventoryResult']?: Omit<ValueTypes["MarketplaceLabelInventoryResult"], "...on MarketplaceLabelInventoryResult">
 }>;
+	["MarketplaceLabelShipmentInventoryInput"]: {
+	/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: ValueTypes["MarketplaceBarcodeStrategy"] | undefined | null | Variable<any, string>,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: ValueTypes["MarketplaceBarcodeFormat"] | undefined | null | Variable<any, string>,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<ValueTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null | Variable<any, string>,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: ValueTypes["ID"] | Variable<any, string>
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+	/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: ValueTypes["ID"] | Variable<any, string>,
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null | Variable<any, string>,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: ValueTypes["MarketplaceBarcodeStrategy"] | undefined | null | Variable<any, string>
+};
+	["MarketplaceLabelShipmentInventoryResult"]: AliasType<{
+	/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory?:ValueTypes["MarketplaceInventoryItem"],
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids?:boolean | `@${string}`,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids?:boolean | `@${string}`,
+		__typename?: boolean | `@${string}`,
+	['...on MarketplaceLabelShipmentInventoryResult']?: Omit<ValueTypes["MarketplaceLabelShipmentInventoryResult"], "...on MarketplaceLabelShipmentInventoryResult">
+}>;
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 	/** Идентификатор КУ-получателя. */
 	braname: string | Variable<any, string>
@@ -8118,6 +8146,7 @@ marketplaceDeclineOrderFromOpenPool?: [{	input: ValueTypes["MarketplaceDeclineOr
 marketplaceDetailKU?: [{	data: ValueTypes["MarketplaceDetailKUInput"] | Variable<any, string>},ValueTypes["MarketplaceKUDetails"]],
 marketplaceFinalizeIssuance?: [{	data: ValueTypes["MarketplaceFinalizeIssuanceInput"] | Variable<any, string>},ValueTypes["MarketplaceIssuanceResult"]],
 marketplaceLabelInventory?: [{	data: ValueTypes["MarketplaceLabelInventoryInput"] | Variable<any, string>},ValueTypes["MarketplaceLabelInventoryResult"]],
+marketplaceLabelShipmentInventory?: [{	data: ValueTypes["MarketplaceLabelShipmentInventoryInput"] | Variable<any, string>},ValueTypes["MarketplaceLabelShipmentInventoryResult"]],
 marketplaceOpenIssuance?: [{	data: ValueTypes["MarketplaceOpenIssuanceInput"] | Variable<any, string>},ValueTypes["MarketplaceIssuanceResult"]],
 marketplaceRejectOffer?: [{	input: ValueTypes["MarketplaceRejectOfferInput"] | Variable<any, string>},ValueTypes["MarketplaceOffer"]],
 marketplaceRejectReturnAtVisit?: [{	data: ValueTypes["MarketplaceRejectReturnAtVisitInput"] | Variable<any, string>},ValueTypes["MarketplaceReturnClaimResult"]],
@@ -16667,6 +16696,33 @@ export type ResolverInputTypes = {
 	inventory?:ResolverInputTypes["MarketplaceInventoryItem"],
 		__typename?: boolean | `@${string}`
 }>;
+	["MarketplaceLabelShipmentInventoryInput"]: {
+	/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: ResolverInputTypes["MarketplaceBarcodeStrategy"] | undefined | null,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: ResolverInputTypes["MarketplaceBarcodeFormat"] | undefined | null,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<ResolverInputTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: ResolverInputTypes["ID"]
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+	/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: ResolverInputTypes["ID"],
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: ResolverInputTypes["MarketplaceBarcodeStrategy"] | undefined | null
+};
+	["MarketplaceLabelShipmentInventoryResult"]: AliasType<{
+	/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory?:ResolverInputTypes["MarketplaceInventoryItem"],
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids?:boolean | `@${string}`,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids?:boolean | `@${string}`,
+		__typename?: boolean | `@${string}`
+}>;
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 	/** Идентификатор КУ-получателя. */
 	braname: string
@@ -17979,6 +18035,7 @@ marketplaceDeclineOrderFromOpenPool?: [{	input: ResolverInputTypes["MarketplaceD
 marketplaceDetailKU?: [{	data: ResolverInputTypes["MarketplaceDetailKUInput"]},ResolverInputTypes["MarketplaceKUDetails"]],
 marketplaceFinalizeIssuance?: [{	data: ResolverInputTypes["MarketplaceFinalizeIssuanceInput"]},ResolverInputTypes["MarketplaceIssuanceResult"]],
 marketplaceLabelInventory?: [{	data: ResolverInputTypes["MarketplaceLabelInventoryInput"]},ResolverInputTypes["MarketplaceLabelInventoryResult"]],
+marketplaceLabelShipmentInventory?: [{	data: ResolverInputTypes["MarketplaceLabelShipmentInventoryInput"]},ResolverInputTypes["MarketplaceLabelShipmentInventoryResult"]],
 marketplaceOpenIssuance?: [{	data: ResolverInputTypes["MarketplaceOpenIssuanceInput"]},ResolverInputTypes["MarketplaceIssuanceResult"]],
 marketplaceRejectOffer?: [{	input: ResolverInputTypes["MarketplaceRejectOfferInput"]},ResolverInputTypes["MarketplaceOffer"]],
 marketplaceRejectReturnAtVisit?: [{	data: ResolverInputTypes["MarketplaceRejectReturnAtVisitInput"]},ResolverInputTypes["MarketplaceReturnClaimResult"]],
@@ -26248,6 +26305,32 @@ export type ModelTypes = {
 		/** Сгенерированные наклейки: одна или несколько в зависимости от стратегии. */
 	inventory: Array<ModelTypes["MarketplaceInventoryItem"]>
 };
+	["MarketplaceLabelShipmentInventoryInput"]: {
+	/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: ModelTypes["MarketplaceBarcodeStrategy"] | undefined | null,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: ModelTypes["MarketplaceBarcodeFormat"] | undefined | null,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<ModelTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: ModelTypes["ID"]
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+	/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: ModelTypes["ID"],
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: ModelTypes["MarketplaceBarcodeStrategy"] | undefined | null
+};
+	["MarketplaceLabelShipmentInventoryResult"]: {
+		/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory: Array<ModelTypes["MarketplaceInventoryItem"]>,
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids: Array<ModelTypes["ID"]>,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids: Array<ModelTypes["ID"]>
+};
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 	/** Идентификатор КУ-получателя. */
 	braname: string
@@ -27931,6 +28014,8 @@ export type ModelTypes = {
 	marketplaceFinalizeIssuance: ModelTypes["MarketplaceIssuanceResult"],
 	/** Оператор КУ маркирует имущество заказа внутренним штрих-кодом (Code128 или EAN-13). */
 	marketplaceLabelInventory: ModelTypes["MarketplaceLabelInventoryResult"],
+	/** Массовая маркировка имущества всех заказов одной партии поставки за один вызов. Идемпотентно: уже промаркированные заказы пропускаются. */
+	marketplaceLabelShipmentInventory: ModelTypes["MarketplaceLabelShipmentInventoryResult"],
 	/** Председатель кооперативного участка открывает выдачу первой подписью акта — заказ готов к получению пайщиком. */
 	marketplaceOpenIssuance: ModelTypes["MarketplaceIssuanceResult"],
 	/** Отклонить Offer с причиной (status → REJECTED) (admin) */
@@ -36745,6 +36830,34 @@ export type GraphQLTypes = {
 	inventory: Array<GraphQLTypes["MarketplaceInventoryItem"]>,
 	['...on MarketplaceLabelInventoryResult']: Omit<GraphQLTypes["MarketplaceLabelInventoryResult"], "...on MarketplaceLabelInventoryResult">
 };
+	["MarketplaceLabelShipmentInventoryInput"]: {
+		/** Стратегия маркировки по умолчанию для всех заказов партии. */
+	default_strategy?: GraphQLTypes["MarketplaceBarcodeStrategy"] | undefined | null,
+	/** Формат штрих-кода для всей партии. По умолчанию — CODE128. */
+	format?: GraphQLTypes["MarketplaceBarcodeFormat"] | undefined | null,
+	/** Перекрытия стратегии для отдельных заказов партии (если состав смешанный). */
+	per_order_overrides?: Array<GraphQLTypes["MarketplaceLabelShipmentInventoryOverride"]> | undefined | null,
+	/** Партия поставки, для всех заказов которой формируются этикетки. */
+	shipment_id: GraphQLTypes["ID"]
+};
+	["MarketplaceLabelShipmentInventoryOverride"]: {
+		/** Заказ в составе партии, для которого задаётся отдельная стратегия. */
+	order_id: GraphQLTypes["ID"],
+	/** Размер упаковки для стратегии PER_PACKAGE именно для этого заказа. */
+	pack_size?: number | undefined | null,
+	/** Стратегия маркировки именно для этого заказа партии. */
+	strategy?: GraphQLTypes["MarketplaceBarcodeStrategy"] | undefined | null
+};
+	["MarketplaceLabelShipmentInventoryResult"]: {
+	__typename: "MarketplaceLabelShipmentInventoryResult",
+	/** Сгенерированные наклейки по всем промаркированным заказам партии. */
+	inventory: Array<GraphQLTypes["MarketplaceInventoryItem"]>,
+	/** Идентификаторы заказов, которые были промаркированы этим вызовом. */
+	labeled_order_ids: Array<GraphQLTypes["ID"]>,
+	/** Идентификаторы заказов, пропущенных из-за уже существующей маркировки (идемпотентность). */
+	skipped_order_ids: Array<GraphQLTypes["ID"]>,
+	['...on MarketplaceLabelShipmentInventoryResult']: Omit<GraphQLTypes["MarketplaceLabelShipmentInventoryResult"], "...on MarketplaceLabelShipmentInventoryResult">
+};
 	["MarketplaceListAplReceptionsByBranameInput"]: {
 		/** Идентификатор КУ-получателя. */
 	braname: string
@@ -38520,6 +38633,8 @@ export type GraphQLTypes = {
 	marketplaceFinalizeIssuance: GraphQLTypes["MarketplaceIssuanceResult"],
 	/** Оператор КУ маркирует имущество заказа внутренним штрих-кодом (Code128 или EAN-13). */
 	marketplaceLabelInventory: GraphQLTypes["MarketplaceLabelInventoryResult"],
+	/** Массовая маркировка имущества всех заказов одной партии поставки за один вызов. Идемпотентно: уже промаркированные заказы пропускаются. */
+	marketplaceLabelShipmentInventory: GraphQLTypes["MarketplaceLabelShipmentInventoryResult"],
 	/** Председатель кооперативного участка открывает выдачу первой подписью акта — заказ готов к получению пайщиком. */
 	marketplaceOpenIssuance: GraphQLTypes["MarketplaceIssuanceResult"],
 	/** Отклонить Offer с причиной (status → REJECTED) (admin) */
@@ -42722,6 +42837,8 @@ type ZEUS_VARIABLES = {
 	["MarketplaceIssueActSignedDocumentInput"]: ValueTypes["MarketplaceIssueActSignedDocumentInput"];
 	["MarketplaceIssueActSignedMetaDocumentInput"]: ValueTypes["MarketplaceIssueActSignedMetaDocumentInput"];
 	["MarketplaceLabelInventoryInput"]: ValueTypes["MarketplaceLabelInventoryInput"];
+	["MarketplaceLabelShipmentInventoryInput"]: ValueTypes["MarketplaceLabelShipmentInventoryInput"];
+	["MarketplaceLabelShipmentInventoryOverride"]: ValueTypes["MarketplaceLabelShipmentInventoryOverride"];
 	["MarketplaceListAplReceptionsByBranameInput"]: ValueTypes["MarketplaceListAplReceptionsByBranameInput"];
 	["MarketplaceListCatalogInput"]: ValueTypes["MarketplaceListCatalogInput"];
 	["MarketplaceListConsolidatedRequestsInput"]: ValueTypes["MarketplaceListConsolidatedRequestsInput"];


### PR DESCRIPTION
## Контекст

Зонтичный [PR #405](https://github.com/coopenomics/mono/pull/405) Эпика 11 merged 2026-05-19. Этот PR закрывает оставшиеся технические долги MVP «Стол заказов»:

- **598-15 FR45 AC5** — отсутствовавшие jest-тесты compensating-rollback для signSupp/signChair;
- **598-21 frontend** — batch-flow на странице `OperatorInventoryLabeling` (backend mutation `marketplaceLabelShipmentInventory` уже в #405).

## Что меняется

### Backend (598-15 FR45 AC5)
- `marketplace-apl-reception.service.spec.ts` — 6 jest-тестов:
  - `signAsSupplier` / `signAsChairman` при `chainPort.signSupp` / `signChair` throws → `ConflictException`, `receptionRepo.applySignatures` не вызывается, status объекта в памяти не меняется;
  - повторная подпись после failure идемпотентна: новый chain submit → success → status сдвигается на `PENDING_CHAIRMAN_RECEPTION_SIGN` / `ACCEPTED_TO_COOP`;
  - гарды на неверный статус (`ACCEPTED_TO_COOP` для supplier-sign, `PENDING_SUPPLIER_SIGN` для chairman-sign) не доходят до chainPort.
- Все 6 тестов проходят локально за 76 сек (`pnpm jest src/extensions/marketplace/application/services/marketplace-apl-reception.service.spec.ts`).

### SDK
- `mutations/marketplace/labelShipmentInventory.ts` — новая mutation `marketplaceLabelShipmentInventory`.
- `selectors/marketplace/inventorySelector.ts` — `marketplaceLabelShipmentInventoryResultSelector` с полями `inventory / labeled_order_ids / skipped_order_ids`.
- Перегенерирован `zeus/` под актуальную `schema.gql` через `pnpm generate-schema && pnpm generate-client`.

### Frontend (598-21)
- `OperatorInventoryLabelingPage.vue`:
  - `q-btn-toggle` переключает режим «Маркировка партии целиком» (по умолчанию) / «Поштучно по заказу»;
  - в batch-режиме: `q-select` партии (из `marketplaceListShipments` со статусами `SUPPLY_PREPARED` / `RECEPTION_IN_PROGRESS`), `q-select` стратегии по умолчанию (`PER_ORDER` / `PER_UNIT` / `PER_PACKAGE` / null = из карточки товара), `q-select` формата (CODE128 / EAN13);
  - вызов `marketplaceLabelShipmentInventory` с `shipment_id` + `default_strategy` + `format`;
  - идемпотентность отображается в toast: «Партия промаркирована. Заказов в работе: N. Пропущено уже промаркированных: M.» — `skipped_order_ids.length` из ответа;
  - после успеха автоматически подтягивается braname партии и перезагружается инвентарь правой колонки;
  - `@media print` обновлён под A4: `grid-template-columns: repeat(3, 1fr)`, `gap: 4mm`, `@page { size: A4; margin: 8mm }`, `page-break-inside: avoid` на этикетку.
- `api/index.ts` — добавлены `fetchShipmentsForLabeling` (фильтр по статусам на клиенте) и `labelShipmentInventory`.

## Что закрывается в _blago

- 598-15 «FR45 signing infrastructure» AC5 → ON_REVIEW (готов к закрытию после merge);
- 598-21 «batch-маркировка штрих-кодом» AC2-5 → ON_REVIEW (готов к закрытию после merge);
- Stories 11.2 + 11.3 — статусы в _blago переведены в COMPLETED (off-chain слой полностью покрыт в #405).

## Test plan

- [x] Локальный jest: 6/6 marketplace-apl-reception.service.spec.ts passed;
- [ ] CI: pnpm build SDK + pnpm typecheck desktop + pnpm jest controller — должно проходить чисто;
- [ ] Smoke на dev-стенде:
  - открыть `/marketplace/operator-inventory-labeling`;
  - выбрать партию в статусе SUPPLY_PREPARED → стратегию `PER_UNIT` → «Промаркировать партию»;
  - проверить что toast содержит количество labeled/skipped, инвентарь подгрузился справа;
  - нажать «Печать партии» → preview должен показать 3 этикетки на ряд на A4;
  - повторно нажать «Промаркировать партию» по той же партии → все labeled_order_ids уходят в skipped_order_ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)