### PR TITLE
fix(capital/convertsegm): линковать 1080 к пакету через newlink, не make_complete_document

### DIFF
--- a/components/contracts/cpp/capital/app/result_submission/push_result/convertsegm.cpp
+++ b/components/contracts/cpp/capital/app/result_submission/push_result/convertsegm.cpp
@@ -112,12 +112,15 @@ void capital::convertsegm(eosio::name coopname, eosio::name username,
   // Инкрементируем счётчик сконвертированных сегментов
   Capital::Projects::increment_converted_segments(coopname, current_project.id);
 
-  // Регистрируем заявление о трансляции (1080) в реестре документов и сразу
-  // помечаем процесс p.cap.rid завершённым: package = result_hash — анкер процесса.
-  // make_complete_document шлёт newsubmitted + newresolved одной парой, off-chain
-  // controller видит документ в registry со статусом completed.
-  // Делаем ДО delete_result, чтобы линковка прошла, пока result_hash ещё анкер.
-  Soviet::make_complete_document(
+  // Линкуем заявление о трансляции (1080) к пакету процесса p.cap.rid
+  // (package = result_hash, ведущий документ пакета — заявление о внесении РИД, 1040).
+  // Не make_complete_document: тот вытаскивает 1080 на верхний уровень реестра
+  // как самостоятельный документ. Нужен newlink — тот же канон, что в signact1/signact2:
+  // off-chain controller добавляет документ в группу пакета по action+package, не как top-level.
+  // Делаем ДО delete_result, чтобы линковка прошла, пока result_hash ещё анкер процесса.
+  Action::send<newlink_interface>(
+    _soviet,
+    "newlink"_n,
     _capital,
     coopname,
     username,


### PR DESCRIPTION
## Что чинит

PR #403 использовал `Soviet::make_complete_document` для регистрации заявления о трансляции (1080) после `convertsegm`. Это вытащило 1080 на верхний уровень реестра как самостоятельный документ — в разделе «Документы» он появился отдельной строкой, а под ним болтались протокол и акт из соседнего пакета (агрегатор подтягивал их по тому же `result_hash` без главного документа).

Правильно — линковать 1080 к существующему пакету процесса `p.cap.rid`, где ведущим документом является **заявление о внесении РИД (1040, statement из `pushrslt`)**.

## Канон

`signact1` / `signact2` уже используют `Action::send<newlink_interface>` для линковки актов к пакету:

```cpp
Action::send<newlink_interface>(_soviet, ""newlink""_n, _capital, coopname, username,
                                Names::Capital::SIGN_ACT*_RESULT, result_hash, act);
```

Здесь применяется тот же паттерн, `action = Names::Capital::CONVERT_SEGMENT` (константа уже в dev из #403, не трогаем), `package = result_hash`. Off-chain controller добавит 1080 в группу пакета 1040, не на верхний уровень.

## Изменено

- `capital/app/result_submission/push_result/convertsegm.cpp`: `Soviet::make_complete_document(...)` → `Action::send<newlink_interface>(_soviet, ""newlink""_n, ...)`

## Что НЕ трогаем

- `verify_document_or_fail(convert_statement, {username})` — оставлен, это безопасность, не связана с проблемой реестра
- `Names::Capital::CONVERT_SEGMENT = ""convertsegm""_n` в `names.hpp` — уже в dev из #403, повторно использовано

## Test plan

- [ ] Редеплой `capital.wasm` на dev-chain
- [ ] E2E: «Получить долю в ОАП» → 1080 генерируется → подписывается → `convertsegm` → проверить:
  - в разделе «Документы» **нет** отдельной строки «Заявление о трансляции» на верхнем уровне
  - 1080 появляется внутри пакета «Заявление о внесении РИД» (1040), рядом с протоколом и актом
- [ ] Сборка локально не выполнялась (сервер под нагрузкой) — CI должен пройти

🤖 Generated with [Claude Code](https://claude.com/claude-code)